### PR TITLE
Revert "Add Storage to KeyStore Database implementation"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ serde_json = "1.0.96"
 thiserror = "1.0.63"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
+rocksdb = "0.22.0"
 hex = "0.4.3"
-rust-bitvmx-storage-backend = { path = "../rust-bitvmx-storage-backend" }
 
 [[bin]]
 name = "key-manager"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -36,10 +36,10 @@ pub enum KeyStoreError {
     OpenError,
 
     #[error("Failed to write secure storage")]
-    WriteError(#[from] storage_backend::error::StorageError),
+    WriteError(#[from] rocksdb::Error),
 
     #[error("Failed to read secure storage")]
-    ReadError(storage_backend::error::StorageError),
+    ReadError(rocksdb::Error),
 
     #[error("Failed to decode data")]
     FailedToDecodeData(#[from] FromSliceError),

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -17,7 +17,7 @@ pub struct KeyManager<K: KeyStore> {
 }
 
 impl <K: KeyStore> KeyManager<K> {
-    pub fn new(network: Network, key_derivation_path: &str, key_derivation_seed: [u8; 32], winternitz_seed: [u8; 32], mut keystore: K) -> Result<Self, KeyManagerError> {
+    pub fn new(network: Network, key_derivation_path: &str, key_derivation_seed: [u8; 32], winternitz_seed: [u8; 32], keystore: K) -> Result<Self, KeyManagerError> {
         let secp = secp256k1::Secp256k1::new();
 
         keystore.store_winternitz_seed(winternitz_seed)?;

--- a/src/keystorage/file.rs
+++ b/src/keystorage/file.rs
@@ -51,14 +51,14 @@ impl KeyStore for FileKeyStore {
         Ok(Some(entry))
     }
 
-    fn store_winternitz_seed(&mut self, seed: [u8; 32]) -> Result<(), KeyStoreError>{
+    fn store_winternitz_seed(&self, seed: [u8; 32]) -> Result<(), KeyStoreError>{
         let entry = self.encrypt_entry(seed.to_vec(), WINTERNITZ_SEED_SIZE)?;
         self.update_entry_at(&entry, WINTERNITZ_SEED_POSITION)?;       
 
         Ok(())
     }
 
-    fn store_key_derivation_seed(&mut self, seed: [u8; 32]) -> Result<(), KeyStoreError>{
+    fn store_key_derivation_seed(&self, seed: [u8; 32]) -> Result<(), KeyStoreError>{
         let entry = self.encrypt_entry(seed.to_vec(), KEY_DERIVATION_SEED_SIZE)?;
         self.update_entry_at(&entry, KEY_DERIVATION_SEED_POSITION)?;       
 

--- a/src/keystorage/keystore.rs
+++ b/src/keystorage/keystore.rs
@@ -5,8 +5,8 @@ use crate::errors::KeyStoreError;
 pub trait KeyStore {
     fn store_keypair(&mut self, private_key: PrivateKey, public_key: PublicKey) -> Result<(), KeyStoreError>;
     fn load_keypair(&self, public_key: &PublicKey) -> Result<Option<(PrivateKey, PublicKey)>, KeyStoreError>;
-    fn store_winternitz_seed(&mut self, master_secret: [u8; 32]) -> Result<(), KeyStoreError>;
+    fn store_winternitz_seed(&self, master_secret: [u8; 32]) -> Result<(), KeyStoreError>;
     fn load_winternitz_seed(&self) -> Result<[u8; 32], KeyStoreError>;
-    fn store_key_derivation_seed(&mut self, seed: [u8; 32]) -> Result<(), KeyStoreError>;
+    fn store_key_derivation_seed(&self, seed: [u8; 32]) -> Result<(), KeyStoreError>;
     fn load_key_derivation_seed(&self) -> Result<[u8; 32], KeyStoreError>;
 }


### PR DESCRIPTION
Reverts FairgateLabs/rust-bitvmx-key-manager#6 We need a PR in the StorageBackend repository to be processed before processing this PR.