### PR TITLE
Remove alias, in favor of: inherit the workspace alias

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[alias]
-buildall = "test --no-run --all-targets --benches --release"


### PR DESCRIPTION
Remove alias, in favor of: inherit the workspace alias

See: https://github.com/FairgateLabs/rust-bitvmx-workspace/pull/25