### PR TITLE
Add Typed Lamport One-Time Signatures Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ name = "key_manager"
 anyhow = "1.0.97"
 bitcoin = { version = "0.32.6", features = ["std", "rand-std", "serde"] }
 bip39 = "2.1.0"
+blake3 = "1.5"
 clap = { version = "4.5.32", features = ["derive"] }
 config = "0.15.11"
 itertools = "0.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,8 @@ name = "winternitz_bench"
 harness = false
 
 [features]
-default = ["transactional", "wots_idx_check"] # transactional is ON by default, strict is OFF
+default = ["transactional", "wots_idx_check", "lamport_idx_check"] # transactional is ON by default, strict is OFF
 wots_idx_check = []
+lamport_idx_check = []
 transactional = []
 strict = []

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ The BitVMX Key Manager implements different strategies for key derivation and st
 - **Storage**: Keys are **not stored** in the keystore - they are regenerated on-demand each time they're needed
 - **Rationale**: Storage scalability - Winternitz signatures require large key sets that would significantly bloat storage requirements. Since they can be deterministically regenerated from the HD seed, we prioritize storage efficiency
 
+#### Lamport One-Time Signature Keys
+
+- **HD Derivation**: Lamport keys are HD derived from the same master seed for consistency, adn are also able to be imported
+- **Storage**: Derived keys are **not stored** in the keystore - they are regenerated on-demand each time they're needed, Imported keys are stored
+- **Rationale**: Storage scalability - Lamport signatures require large key sets that would significantly bloat storage requirements. Since they can be deterministically regenerated from the HD seed, we prioritize storage efficiency. Imported keys are stores, as there is no way to re generate them from the seed. The storage key is the public key compressed using blake3, private materials are fully stored
+
 #### RSA Keys
 
 - **Fresh Entropy**: RSA keys are generated using fresh entropy provided by the user, with **no correlation** to the HD mnemonic

--- a/README.md
+++ b/README.md
@@ -76,11 +76,21 @@ The BitVMX Key Manager implements different strategies for key derivation and st
 
 ### [Signing and verifying a message using Winternitz](examples/sign_verify_winternitz.rs)
 
+### [Deriving Lamport OTS keys](examples/deriving_lamport.rs)
+
+*The key manager also supports Lamport one-time signature keys. Lamport keys are derived and managed similarly to Winternitz keys, with the key pair being generated and only the public key returned for later use in signing operations.*
+
+### [Importing Lamport keys](examples/import_lamport.rs)
+
+### [Signing and verifying a message using Lamport](examples/sign_verify_lamport.rs)
+
 ### [Generating keys, Signing and verifying a message using RSA](examples/rsa.rs)
 
 ### [Signing and verifying Multi-Signatures with MuSig2](examples/sign_verify_musig2.rs)
 
 The `KeyManager` supports MuSig2 multi-signature schemes, allowing multiple parties to jointly produce a single Schnorr signature. See more details on [MuSig2 for Rust](https://docs.rs/musig2/latest/musig2/).
+
+
 
 ## Development Setup
 
@@ -98,12 +108,18 @@ run with `cargo run --example key_gen`
 run with `cargo run --example key_import`
 - **[deriving_winternitz:](examples/deriving_winternitz.rs)**
 run with `cargo run --example deriving_winternitz`
+- **[deriving_lamport:](examples/deriving_lamport.rs)**
+run with `cargo run --example deriving_lamport`
+- **[import_lamport:](examples/import_lamport.rs)**
+run with `cargo run --example import_lamport`
 - **[sign_verify_ecdsa:](examples/sign_verify_ecdsa.rs)**
 run with `cargo run --example sign_verify_ecdsa`
 - **[sign_verify_schnorr_taproot:](examples/sign_verify_schnorr_taproot.rs)**
 run with `cargo run --example sign_verify_schnorr_taproot`
 - **[sign_verify_winternitz:](examples/sign_verify_winternitz.rs)**
 run with `cargo run --example sign_verify_winternitz`
+- **[sign_verify_lamport:](examples/sign_verify_lamport.rs)**
+run with `cargo run --example sign_verify_lamport`
 - **[rsa:](examples/rsa.rs)**
 run with `cargo run --example rsa`
 

--- a/examples/deriving_lamport.rs
+++ b/examples/deriving_lamport.rs
@@ -1,0 +1,26 @@
+mod create;
+
+use create::create_key_manager_example;
+
+use key_manager::lamport::LamportType;
+
+fn main() {
+    // see function code, main is just a wrapper to run the example
+    key_gen_lamport_example();
+}
+
+fn key_gen_lamport_example() {
+    let key_manager = create_key_manager_example("deriving_lamport");
+    // --- Deriving Lamport OTS keys
+
+    // using 1 bit to mimic a garbled circuit wire value
+    let message_bit_length = 1;
+    let lamport_pubkey = key_manager
+        .next_lamport(message_bit_length, LamportType::SHA256)
+        .unwrap();
+    println!(
+        "Lamport public key: {:?}",
+        hex::encode(lamport_pubkey.to_bytes())
+    );
+
+}

--- a/examples/deriving_lamport.rs
+++ b/examples/deriving_lamport.rs
@@ -22,5 +22,4 @@ fn key_gen_lamport_example() {
         "Lamport public key: {:?}",
         hex::encode(lamport_pubkey.to_bytes())
     );
-
 }

--- a/examples/import_lamport.rs
+++ b/examples/import_lamport.rs
@@ -46,7 +46,7 @@ fn import_sign_verify_lamport_example() {
 
     // Create a Lamport signature
     let signature = key_manager
-        .sign_lamport_bit_by_pubkey(message_bit, &lamport_pubkey)
+        .sign_lamport_message_by_pubkey(message_bit, &lamport_pubkey)
         .unwrap();
     println!(
         "(using imported) Lamport signature: {:?}",

--- a/examples/import_lamport.rs
+++ b/examples/import_lamport.rs
@@ -1,0 +1,59 @@
+mod create;
+
+use create::create_key_manager_example;
+
+use bitcoin::key::rand::RngCore;
+use bitcoin::secp256k1;
+
+use key_manager::lamport::{Lamport, LamportType};
+
+fn main() {
+    // see function code, main is just a wrapper to run the example
+    import_sign_verify_lamport_example();
+}
+
+fn import_sign_verify_lamport_example() {
+    let key_manager = create_key_manager_example("sign_verify_lamport");
+
+    // --- Signing and verifying a message using Lamport
+
+    // Create a random message bit (0 or 1) (using bit to mimic the garbled circuit use case)
+    // Commonly, you would hash the message and use the hash as input to the Lamport signature scheme
+
+    /*  In the Fairgate Garbled Circuit use case, they use Scalar
+        we wont introduce the scalar dependency here but, from their code:
+        If you need serialization for persistent storage, Scalar::to_repr() gives you a 32-byte representation, and Scalar::from_repr() reverses it.
+        so we will use some random 32-byte values to mimic the private key parts
+    */
+    let mut rng = secp256k1::rand::thread_rng();
+    let message_bit = (rng.next_u32() % 2) == 1;
+    println!("Message bit: {:?}", message_bit);
+
+    let mut random_bytes_0 = [0u8; 32];
+    rng.fill_bytes(&mut random_bytes_0);
+
+    let mut random_bytes_1 = [0u8; 32];
+    rng.fill_bytes(&mut random_bytes_1);
+
+    // Get the Lamport public key with message bit length = 1 using the SHA-256 hash function
+    let lamport_pubkey = key_manager
+        .import_lamport_private_key(&random_bytes_0, &random_bytes_1, 1usize, LamportType::SHA256)
+        .unwrap();
+
+    // Create a Lamport signature
+    let signature = key_manager
+        .sign_lamport_bit_by_pubkey(message_bit, &lamport_pubkey)
+        .unwrap();
+    println!(
+        "(using imported) Lamport signature: {:?}",
+        hex::encode(signature.to_bytes())
+    );
+
+    // Verify the signature
+    let lamport = Lamport::new();
+    let is_valid = lamport
+        .verify_signature_bit(message_bit, &signature, &lamport_pubkey)
+        .unwrap();
+    println!("(using imported) Is signature valid: {:?}", is_valid);
+    assert!(is_valid);
+}

--- a/examples/import_lamport.rs
+++ b/examples/import_lamport.rs
@@ -37,7 +37,12 @@ fn import_sign_verify_lamport_example() {
 
     // Get the Lamport public key with message bit length = 1 using the SHA-256 hash function
     let lamport_pubkey = key_manager
-        .import_lamport_private_key(&random_bytes_0, &random_bytes_1, 1usize, LamportType::SHA256)
+        .import_lamport_private_key(
+            &random_bytes_0,
+            &random_bytes_1,
+            1usize,
+            LamportType::SHA256,
+        )
         .unwrap();
 
     // Create a Lamport signature

--- a/examples/import_lamport.rs
+++ b/examples/import_lamport.rs
@@ -56,7 +56,7 @@ fn import_sign_verify_lamport_example() {
     // Verify the signature
     let lamport = Lamport::new();
     let is_valid = lamport
-        .verify_signature_bit(message_bit, &signature, &lamport_pubkey)
+        .verify_signature(message_bit, &signature, &lamport_pubkey)
         .unwrap();
     println!("(using imported) Is signature valid: {:?}", is_valid);
     assert!(is_valid);

--- a/examples/import_lamport.rs
+++ b/examples/import_lamport.rs
@@ -55,8 +55,8 @@ fn import_sign_verify_lamport_example() {
 
     // Verify the signature
     let lamport = Lamport::new();
-    let is_valid = lamport
-        .verify_signature(message_bit, &signature, &lamport_pubkey)
+    let (is_valid, _reconstructed_msg) = lamport
+        .verify_signature(Some(message_bit), &signature, &lamport_pubkey)
         .unwrap();
     println!("(using imported) Is signature valid: {:?}", is_valid);
     assert!(is_valid);

--- a/examples/import_lamport.rs
+++ b/examples/import_lamport.rs
@@ -15,20 +15,19 @@ fn main() {
 fn import_sign_verify_lamport_example() {
     let key_manager = create_key_manager_example("sign_verify_lamport");
 
-    // --- Signing and verifying a message using Lamport
+    // --- Importing a Lamport private key, Signing and verifying a message using Lamport
 
     // Create a random message bit (0 or 1) (using bit to mimic the garbled circuit use case)
     // Commonly, you would hash the message and use the hash as input to the Lamport signature scheme
-
-    /*  In the Fairgate Garbled Circuit use case, they use Scalar
-        we wont introduce the scalar dependency here but, from their code:
-        If you need serialization for persistent storage, Scalar::to_repr() gives you a 32-byte representation, and Scalar::from_repr() reverses it.
-        so we will use some random 32-byte values to mimic the private key parts
-    */
     let mut rng = secp256k1::rand::thread_rng();
-    let message_bit = (rng.next_u32() % 2) == 1;
+    let message_bit = (rng.next_u32() % 2) == 1; // random boolean value (0 = false or 1 = true)
     println!("Message bit: {:?}", message_bit);
 
+    /*  In the Fairgate Garbled Circuit use case, they use Scalar for the private key components,
+        we wont introduce the scalar dependency here but from their code:
+        "If you need serialization for persistent storage, Scalar::to_repr() gives you a 32-byte representation, and Scalar::from_repr() reverses it."
+        so we will use some random 32-byte values to mimic the private key parts
+    */
     let mut random_bytes_0 = [0u8; 32];
     rng.fill_bytes(&mut random_bytes_0);
 
@@ -61,4 +60,6 @@ fn import_sign_verify_lamport_example() {
         .unwrap();
     println!("(using imported) Is signature valid: {:?}", is_valid);
     assert!(is_valid);
+
+    // To sign / verify larger messages with many bits, or also expressed in bytes, see the sign_verify_lamport example
 }

--- a/examples/sign_verify_lamport.rs
+++ b/examples/sign_verify_lamport.rs
@@ -1,0 +1,49 @@
+mod create;
+
+use create::create_key_manager_example;
+
+use bitcoin::key::rand::RngCore;
+use bitcoin::secp256k1;
+
+use key_manager::lamport::{Lamport, LamportType};
+
+fn main() {
+    // see function code, main is just a wrapper to run the example
+    sign_verify_lamport_example();
+}
+
+fn sign_verify_lamport_example() {
+    let key_manager = create_key_manager_example("sign_verify_lamport");
+
+    // --- Signing and verifying a message using Lamport
+
+    // Create a random message bit (0 or 1) (using bit to mimic the garbled circuit use case)
+    // Commonly, you would hash the message and use the hash as input to the Lamport signature scheme
+    let mut rng = secp256k1::rand::thread_rng();
+    let message_bit = (rng.next_u32() % 2) == 1;
+    println!("Message bit: {:?}", message_bit);
+
+    // Using next - recommended
+
+    // Get the Lamport public key with message bit length = 1 using the SHA-256 hash function
+    let lamport_pubkey = key_manager
+        .next_lamport(1, LamportType::SHA256)
+        .unwrap();
+
+    // Create a Lamport signature
+    let signature = key_manager
+        .sign_lamport_bit_by_pubkey(message_bit, &lamport_pubkey)
+        .unwrap();
+    println!(
+        "(using next) Lamport signature: {:?}",
+        hex::encode(signature.to_bytes())
+    );
+
+    // Verify the signature
+    let lamport = Lamport::new();
+    let is_valid = lamport
+        .verify_signature_bit(message_bit, &signature, &lamport_pubkey)
+        .unwrap();
+    println!("(using next) Is signature valid: {:?}", is_valid);
+    assert!(is_valid);
+}

--- a/examples/sign_verify_lamport.rs
+++ b/examples/sign_verify_lamport.rs
@@ -2,9 +2,9 @@ mod create;
 
 use create::create_key_manager_example;
 
+use bitcoin::hashes::{sha256, Hash};
 use bitcoin::key::rand::RngCore;
 use bitcoin::secp256k1;
-use bitcoin::hashes::{sha256, Hash};
 
 use key_manager::lamport::{bits_to_bytes, Lamport, LamportType};
 
@@ -49,9 +49,7 @@ fn sign_verify_lamport_example() {
     // --- Signing and verifying a 10-bit message using sign_lamport_message_by_pubkey
 
     // Create a random 10-bit message
-    let message_bits: Vec<bool> = (0..10)
-        .map(|_| (rng.next_u32() % 2) == 1)
-        .collect();
+    let message_bits: Vec<bool> = (0..10).map(|_| (rng.next_u32() % 2) == 1).collect();
     println!("\n10-bit message: {:?}", message_bits);
 
     // Get the Lamport public key with message bit length = 10
@@ -88,7 +86,9 @@ fn sign_verify_lamport_example() {
 
     let message_bit_lenght_padded_to_use_bytes = message_bits.len() + padding as usize;
     // if the user want to use the bytes methods, it should indicate the message length with padding, otherwise will get an MessageLengthMismatch error at signing time
-    let lamport_pubkey_bytes = key_manager.next_lamport(message_bit_lenght_padded_to_use_bytes, LamportType::SHA256).unwrap();
+    let lamport_pubkey_bytes = key_manager
+        .next_lamport(message_bit_lenght_padded_to_use_bytes, LamportType::SHA256)
+        .unwrap();
 
     // Create a Lamport signature for the message bytes
     let signature_bytes = key_manager
@@ -136,5 +136,4 @@ fn sign_verify_lamport_example() {
     println!("Is string message signature valid: {:?}", is_valid_string);
     assert!(is_valid_string);
     println!("\n✓ String message signed and verified successfully!");
-
 }

--- a/examples/sign_verify_lamport.rs
+++ b/examples/sign_verify_lamport.rs
@@ -40,8 +40,8 @@ fn sign_verify_lamport_example() {
 
     // Verify the signature
     let lamport = Lamport::new();
-    let is_valid = lamport
-        .verify_signature(message_bit, &signature, &lamport_pubkey)
+    let (is_valid, _reconstructed_msg) = lamport
+        .verify_signature(Some(message_bit), &signature, &lamport_pubkey)
         .unwrap();
     println!("(using next) Is signature valid: {:?}", is_valid);
     assert!(is_valid);
@@ -65,8 +65,8 @@ fn sign_verify_lamport_example() {
     );
 
     // Verify the signature
-    let is_valid_10bit = lamport
-        .verify_signature(&message_bits, &signature_10bit, &lamport_pubkey_10bit)
+    let (is_valid_10bit, _reconstructed_msg_10bit) = lamport
+        .verify_signature(Some(&message_bits), &signature_10bit, &lamport_pubkey_10bit)
         .unwrap();
     println!("Is 10-bit signature valid: {:?}", is_valid_10bit);
     assert!(is_valid_10bit);
@@ -100,8 +100,8 @@ fn sign_verify_lamport_example() {
     );
 
     // Verify the signature
-    let is_valid_bytes = lamport
-        .verify_signature(&message_bytes, &signature_bytes, &lamport_pubkey_bytes)
+    let (is_valid_bytes, _reconstructed_msg_bytes) = lamport
+        .verify_signature(Some(&message_bytes), &signature_bytes, &lamport_pubkey_bytes)
         .unwrap();
     println!("Is byte signature valid: {:?}", is_valid_bytes);
     assert!(is_valid_bytes);
@@ -130,8 +130,8 @@ fn sign_verify_lamport_example() {
     );
 
     // Verify the signature
-    let is_valid_string = lamport
-        .verify_signature(&message_digest, &signature_string, &lamport_pubkey_string)
+    let (is_valid_string, _reconstructed_msg_string) = lamport
+        .verify_signature(Some(&message_digest), &signature_string, &lamport_pubkey_string)
         .unwrap();
     println!("Is string message signature valid: {:?}", is_valid_string);
     assert!(is_valid_string);

--- a/examples/sign_verify_lamport.rs
+++ b/examples/sign_verify_lamport.rs
@@ -4,8 +4,9 @@ use create::create_key_manager_example;
 
 use bitcoin::key::rand::RngCore;
 use bitcoin::secp256k1;
+use bitcoin::hashes::{sha256, Hash};
 
-use key_manager::lamport::{Lamport, LamportType};
+use key_manager::lamport::{bits_to_bytes, Lamport, LamportType};
 
 fn main() {
     // see function code, main is just a wrapper to run the example
@@ -44,4 +45,93 @@ fn sign_verify_lamport_example() {
         .unwrap();
     println!("(using next) Is signature valid: {:?}", is_valid);
     assert!(is_valid);
+
+    // --- Signing and verifying a 10-bit message using sign_lamport_message_by_pubkey
+
+    // Create a random 10-bit message
+    let message_bits: Vec<bool> = (0..10)
+        .map(|_| (rng.next_u32() % 2) == 1)
+        .collect();
+    println!("\n10-bit message: {:?}", message_bits);
+
+    // Get the Lamport public key with message bit length = 10
+    let lamport_pubkey_10bit = key_manager.next_lamport(10, LamportType::SHA256).unwrap();
+
+    // Create a Lamport signature for the message
+    let signature_10bit = key_manager
+        .sign_lamport_message_by_pubkey(&message_bits, &lamport_pubkey_10bit)
+        .unwrap();
+    println!(
+        "Lamport 10-bit signature: {:?}",
+        hex::encode(signature_10bit.to_bytes())
+    );
+
+    // Verify the signature
+    let is_valid_10bit = lamport
+        .verify_signature(&message_bits, &signature_10bit, &lamport_pubkey_10bit)
+        .unwrap();
+    println!("Is 10-bit signature valid: {:?}", is_valid_10bit);
+    assert!(is_valid_10bit);
+
+    // --- Signing and verifying a message using sign_lamport_message_bytes_by_pubkey
+
+    // Convert the 10-bit message to bytes
+    let (message_bytes, padding) = bits_to_bytes(&message_bits).unwrap();
+    println!(
+        "\nMessage as bytes (with {} padding bits): {:?}",
+        padding,
+        hex::encode(&message_bytes)
+    );
+
+    // Note: For bytes, we need 16 bits (2 bytes) as the message length
+    // since bits_to_bytes adds padding to make it a multiple of 8
+    let lamport_pubkey_bytes = key_manager.next_lamport(16, LamportType::SHA256).unwrap();
+
+    // Create a Lamport signature for the message bytes
+    let signature_bytes = key_manager
+        .sign_lamport_message_bytes_by_pubkey(&message_bytes, &lamport_pubkey_bytes)
+        .unwrap();
+    println!(
+        "Lamport byte signature: {:?}",
+        hex::encode(signature_bytes.to_bytes())
+    );
+
+    // Verify the signature
+    let is_valid_bytes = lamport
+        .verify_signature_bytes(&message_bytes, &signature_bytes, &lamport_pubkey_bytes)
+        .unwrap();
+    println!("Is byte signature valid: {:?}", is_valid_bytes);
+    assert!(is_valid_bytes);
+
+    // --- Signing and verifying a string message using SHA256 hash
+
+    // Define a string message
+    let message = "hi im the message to be signed with lamport :)";
+    println!("\n\nString message: {:?}", message);
+
+    // Hash the message with SHA256 to get a 32-byte digest
+    let message_hash = sha256::Hash::hash(message.as_bytes());
+    let message_digest = message_hash.to_byte_array();
+    println!("SHA256 digest: {:?}", hex::encode(message_digest));
+
+    // For a 32-byte digest, we need 256 bits (32 * 8) as the message length
+    let lamport_pubkey_string = key_manager.next_lamport(256, LamportType::SHA256).unwrap();
+
+    // Create a Lamport signature for the message digest
+    let signature_string = key_manager
+        .sign_lamport_message_bytes_by_pubkey(&message_digest, &lamport_pubkey_string)
+        .unwrap();
+    println!(
+        "Lamport signature for string message: {:?}",
+        hex::encode(signature_string.to_bytes())
+    );
+
+    // Verify the signature
+    let is_valid_string = lamport
+        .verify_signature_bytes(&message_digest, &signature_string, &lamport_pubkey_string)
+        .unwrap();
+    println!("Is string message signature valid: {:?}", is_valid_string);
+    assert!(is_valid_string);
+    println!("\n✓ String message signed and verified successfully!");
+
 }

--- a/examples/sign_verify_lamport.rs
+++ b/examples/sign_verify_lamport.rs
@@ -31,7 +31,7 @@ fn sign_verify_lamport_example() {
 
     // Create a Lamport signature
     let signature = key_manager
-        .sign_lamport_bit_by_pubkey(message_bit, &lamport_pubkey)
+        .sign_lamport_message_by_pubkey(message_bit, &lamport_pubkey)
         .unwrap();
     println!(
         "(using next) Lamport signature: {:?}",
@@ -92,7 +92,7 @@ fn sign_verify_lamport_example() {
 
     // Create a Lamport signature for the message bytes
     let signature_bytes = key_manager
-        .sign_lamport_message_bytes_by_pubkey(&message_bytes, &lamport_pubkey_bytes)
+        .sign_lamport_message_by_pubkey(&message_bytes, &lamport_pubkey_bytes)
         .unwrap();
     println!(
         "Lamport byte signature: {:?}",
@@ -122,7 +122,7 @@ fn sign_verify_lamport_example() {
 
     // Create a Lamport signature for the message digest
     let signature_string = key_manager
-        .sign_lamport_message_bytes_by_pubkey(&message_digest, &lamport_pubkey_string)
+        .sign_lamport_message_by_pubkey(&message_digest, &lamport_pubkey_string)
         .unwrap();
     println!(
         "Lamport signature for string message: {:?}",

--- a/examples/sign_verify_lamport.rs
+++ b/examples/sign_verify_lamport.rs
@@ -26,9 +26,7 @@ fn sign_verify_lamport_example() {
     // Using next - recommended
 
     // Get the Lamport public key with message bit length = 1 using the SHA-256 hash function
-    let lamport_pubkey = key_manager
-        .next_lamport(1, LamportType::SHA256)
-        .unwrap();
+    let lamport_pubkey = key_manager.next_lamport(1, LamportType::SHA256).unwrap();
 
     // Create a Lamport signature
     let signature = key_manager

--- a/examples/sign_verify_lamport.rs
+++ b/examples/sign_verify_lamport.rs
@@ -101,7 +101,11 @@ fn sign_verify_lamport_example() {
 
     // Verify the signature
     let (is_valid_bytes, _reconstructed_msg_bytes) = lamport
-        .verify_signature(Some(&message_bytes), &signature_bytes, &lamport_pubkey_bytes)
+        .verify_signature(
+            Some(&message_bytes),
+            &signature_bytes,
+            &lamport_pubkey_bytes,
+        )
         .unwrap();
     println!("Is byte signature valid: {:?}", is_valid_bytes);
     assert!(is_valid_bytes);
@@ -131,7 +135,11 @@ fn sign_verify_lamport_example() {
 
     // Verify the signature
     let (is_valid_string, _reconstructed_msg_string) = lamport
-        .verify_signature(Some(&message_digest), &signature_string, &lamport_pubkey_string)
+        .verify_signature(
+            Some(&message_digest),
+            &signature_string,
+            &lamport_pubkey_string,
+        )
         .unwrap();
     println!("Is string message signature valid: {:?}", is_valid_string);
     assert!(is_valid_string);

--- a/examples/sign_verify_lamport.rs
+++ b/examples/sign_verify_lamport.rs
@@ -85,7 +85,10 @@ fn sign_verify_lamport_example() {
 
     // Note: For bytes, we need 16 bits (2 bytes) as the message length
     // since bits_to_bytes adds padding to make it a multiple of 8
-    let lamport_pubkey_bytes = key_manager.next_lamport(16, LamportType::SHA256).unwrap();
+
+    let message_bit_lenght_padded_to_use_bytes = message_bits.len() + padding as usize;
+    // if the user want to use the bytes methods, it should indicate the message length with padding, otherwise will get an MessageLengthMismatch error at signing time
+    let lamport_pubkey_bytes = key_manager.next_lamport(message_bit_lenght_padded_to_use_bytes, LamportType::SHA256).unwrap();
 
     // Create a Lamport signature for the message bytes
     let signature_bytes = key_manager

--- a/examples/sign_verify_lamport.rs
+++ b/examples/sign_verify_lamport.rs
@@ -41,7 +41,7 @@ fn sign_verify_lamport_example() {
     // Verify the signature
     let lamport = Lamport::new();
     let is_valid = lamport
-        .verify_signature_bit(message_bit, &signature, &lamport_pubkey)
+        .verify_signature(message_bit, &signature, &lamport_pubkey)
         .unwrap();
     println!("(using next) Is signature valid: {:?}", is_valid);
     assert!(is_valid);
@@ -101,7 +101,7 @@ fn sign_verify_lamport_example() {
 
     // Verify the signature
     let is_valid_bytes = lamport
-        .verify_signature_bytes(&message_bytes, &signature_bytes, &lamport_pubkey_bytes)
+        .verify_signature(&message_bytes, &signature_bytes, &lamport_pubkey_bytes)
         .unwrap();
     println!("Is byte signature valid: {:?}", is_valid_bytes);
     assert!(is_valid_bytes);
@@ -131,7 +131,7 @@ fn sign_verify_lamport_example() {
 
     // Verify the signature
     let is_valid_string = lamport
-        .verify_signature_bytes(&message_digest, &signature_string, &lamport_pubkey_string)
+        .verify_signature(&message_digest, &signature_string, &lamport_pubkey_string)
         .unwrap();
     println!("Is string message signature valid: {:?}", is_valid_string);
     assert!(is_valid_string);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -73,11 +73,17 @@ pub enum KeyManagerError {
     #[error("Failed to load Next Winternitz index from key store")]
     NextWinternitzIndexNotFound,
 
+    #[error("Failed to load Next Lamport index from key store")]
+    NextLamportIndexNotFound,
+
     #[error("Failed to load Mnemonic passphrase from key store")]
     MnemonicPassphraseNotFound,
 
     #[error("Failed to load Winternitz seed from key store")]
     WinternitzSeedNotFound,
+
+    #[error("Failed to load Lamport seed from key store")]
+    LamportSeedNotFound,
 
     #[error("Failed to load the BIP39 key derivation seed from key store")]
     KeyDerivationSeedNotFound,
@@ -87,6 +93,9 @@ pub enum KeyManagerError {
 
     #[error("Corrupted Winternitz seed")]
     CorruptedWinternitzSeed,
+
+    #[error("Corrupted Lamport seed")]
+    CorruptedLamportSeed,
 
     #[error("Failed to convert data to byte array")]
     CorruptedData,
@@ -120,6 +129,12 @@ pub enum KeyManagerError {
 
     #[error("Corrupted Winternitz index bitmap")]
     CorruptedWinternitzIndexBitmap,
+
+    #[error("Lamport index {0} has already been used")]
+    LamportIndexAlreadyUsed(u32),
+
+    #[error("Corrupted Lamport index bitmap")]
+    CorruptedLamportIndexBitmap,
 }
 
 #[derive(Error, Debug)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -219,4 +219,10 @@ pub enum LamportError {
 
     #[error("Invalid bit length {0} (must be multiple of 8)")]
     InvalidBitLength(usize),
+
+    #[error("Message bit length {0} exceeds maximum allowed length of {1} bits")]
+    MessageBitLengthExceedsMax(usize, usize),
+
+    #[error("Byte length {0} exceeds maximum allowed length of {1} bytes")]
+    ByteLengthExceedsMax(usize, usize),
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -252,4 +252,10 @@ pub enum LamportError {
 
     #[error("Byte length {0} exceeds maximum allowed length of {1} bytes")]
     ByteLengthExceedsMax(usize, usize),
+
+    #[error("Imported keys cannot have a derivation index (found: {0})")]
+    ImportedKeyWithDerivationIndex(u32),
+
+    #[error("Derived keys must have a derivation index")]
+    DerivedKeyWithoutDerivationIndex,
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -112,6 +112,9 @@ pub enum KeyManagerError {
     #[error("Lamport key not found")]
     LamportKeyNotFound,
 
+    #[error("Lamport key derivation index not found")]
+    LamportKeyDerivationIndexNotFound,
+
     #[error("Invalid RSA key size: {0}")]
     InvalidRSAKeySize(String),
 
@@ -132,6 +135,15 @@ pub enum KeyManagerError {
 
     #[error("Lamport index {0} has already been used")]
     LamportIndexAlreadyUsed(u32),
+
+    #[error("Lamport imported key has already been used")]
+    LamportImportedKeyAlreadyUsed,
+
+    #[error("Lamport key is not marked as imported")]
+    LamportKeyNotMarkedAsImported,
+
+    #[error("Lamport private key not found")]
+    LamportPrivateKeyNotFound,
 
     #[error("Corrupted Lamport index bitmap")]
     CorruptedLamportIndexBitmap,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -230,7 +230,7 @@ pub enum LamportError {
     InvalidSignatureLength(usize, usize),
 
     #[error("Public key length {0} bytes does not match expected length {1} bytes")]
-    InvalidPublicKeyLength(usize, usize),
+    InvalidKeyLength(usize, usize),
 
     #[error("Extra data in Lamport Public Key missing {0}")]
     ExtraDataMissing(String),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -147,6 +147,9 @@ pub enum KeyManagerError {
 
     #[error("Corrupted Lamport index bitmap")]
     CorruptedLamportIndexBitmap,
+
+    #[error("Index overflow: cannot generate more keys")]
+    IndexOverflow,
 }
 
 #[derive(Error, Debug)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -37,6 +37,9 @@ pub enum KeyManagerError {
     #[error("Invalid private key")]
     InvalidPrivateKey,
 
+    #[error("Invalid lamport private key")]
+    InvalidLamportPrivateKey,
+
     #[error("Invalid Mnemonic")]
     InvalidMnemonic,
 
@@ -93,6 +96,9 @@ pub enum KeyManagerError {
 
     #[error("Rsa key not found")]
     RsaKeyNotFound,
+
+    #[error("Lamport key not found")]
+    LamportKeyNotFound,
 
     #[error("Invalid RSA key size: {0}")]
     InvalidRSAKeySize(String),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -22,6 +22,9 @@ pub enum KeyManagerError {
     #[error("Failed to create new Winternitz key")]
     WinternitzGenerationError(#[from] WinternitzError),
 
+    #[error("Failed to create new Lamport key")]
+    LamportGenerationError(#[from] LamportError),
+
     #[error("Failed to tweak secret key")]
     FailedToTweakKey(#[from] secp256k1::Error),
 
@@ -180,4 +183,40 @@ pub enum WinternitzError {
 
     #[error("Extra data in Winternitz Public Key missing {0}")]
     ExtraDataMissing(String),
+}
+
+#[derive(Error, Debug)]
+pub enum LamportError {
+    #[error("Index overflow: cannot generate more keys")]
+    IndexOverflow,
+
+    #[error("Invalid Lamport type {0}")]
+    InvalidLamportType(String),
+
+    #[error("Hash size of {0} bytes does not match expected size {1}")]
+    InvalidHashSize(usize, usize),
+
+    #[error("Hash size of {0} bytes does not match expected size {1}")]
+    HashSizeMismatch(usize, usize),
+
+    #[error("Signature length {0} bytes does not match expected length {1} bytes")]
+    InvalidSignatureLength(usize, usize),
+
+    #[error("Public key length {0} bytes does not match expected length {1} bytes")]
+    InvalidPublicKeyLength(usize, usize),
+
+    #[error("Extra data in Lamport Public Key missing {0}")]
+    ExtraDataMissing(String),
+
+    #[error("Index {0} out of bounds (length: {1})")]
+    IndexOutOfBounds(usize, usize),
+
+    #[error("Message length {0} bits does not match expected length {1} bits")]
+    MessageLengthMismatch(usize, usize),
+
+    #[error("Invalid bit value {0} (expected 0 or 1)")]
+    InvalidBitValue(u8),
+
+    #[error("Invalid bit length {0} (must be multiple of 8)")]
+    InvalidBitLength(usize),
 }

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -1450,6 +1450,18 @@ impl KeyManager {
             let index = public_key
                 .derivation_index()
                 .ok_or(KeyManagerError::LamportKeyDerivationIndexNotFound)?;
+
+            // Validate message length matches the public key's expected message bit length
+            let expected_bit_length = public_key.message_bit_length()?;
+            if message_bits.len() != expected_bit_length {
+                return Err(KeyManagerError::LamportGenerationError(
+                    crate::errors::LamportError::MessageLengthMismatch(
+                        message_bits.len(),
+                        expected_bit_length,
+                    ),
+                ));
+            }
+
             self.sign_lamport_message_by_index(message_bits, public_key.hash_type(), index)
         }
     }
@@ -1487,8 +1499,10 @@ impl KeyManager {
     }
 
     // For one-time lamport keys
-    // TODO: make this fun private to force sign by key? Protocol should store the key and not the index
-    pub fn sign_lamport_message_by_index(
+    /*  if this method is used directly, its the responsibility of the caller to check that the message bits lenght
+        is equal to the one specified in the public key, otherwise we are signing with a virtually extended key
+    */
+    fn sign_lamport_message_by_index(
         &self,
         message_bits: &[bool],
         key_type: LamportType,
@@ -1546,6 +1560,19 @@ impl KeyManager {
             let index = public_key
                 .derivation_index()
                 .ok_or(KeyManagerError::LamportKeyDerivationIndexNotFound)?;
+
+            // Validate message length matches the public key's expected message bit length
+            let expected_bit_length = public_key.message_bit_length()?;
+            let message_bit_length = message_bytes.len() * 8;
+            if message_bit_length != expected_bit_length {
+                return Err(KeyManagerError::LamportGenerationError(
+                    crate::errors::LamportError::MessageLengthMismatch(
+                        message_bit_length,
+                        expected_bit_length,
+                    ),
+                ));
+            }
+
             self.sign_lamport_message_bytes_by_index(message_bytes, public_key.hash_type(), index)
         }
     }
@@ -1583,8 +1610,10 @@ impl KeyManager {
     }
 
     // For one-time lamport keys
-    // TODO: make this fun private to force sign by key? Protocol should store the key and not the index
-    pub fn sign_lamport_message_bytes_by_index(
+    /*  if this method is used directly, its the responsibility of the caller to check that the message bits lenght
+        is equal to the one specified in the public key, otherwise we are signing with a virtually extended key
+    */
+    fn sign_lamport_message_bytes_by_index(
         &self,
         message_bytes: &[u8],
         key_type: LamportType,
@@ -1645,6 +1674,15 @@ impl KeyManager {
             let index = public_key
                 .derivation_index()
                 .ok_or(KeyManagerError::LamportKeyDerivationIndexNotFound)?;
+
+            // Validate message length matches the public key's expected message bit length
+            let expected_bit_length = public_key.message_bit_length()?;
+            if expected_bit_length != 1 {
+                return Err(KeyManagerError::LamportGenerationError(
+                    crate::errors::LamportError::MessageLengthMismatch(1, expected_bit_length),
+                ));
+            }
+
             self.sign_lamport_bit_by_index(message_bit, public_key.hash_type(), index)
         }
     }
@@ -1682,8 +1720,10 @@ impl KeyManager {
     }
 
     // For one-time lamport keys
-    // TODO: make this fun private to force sign by key? Protocol should store the key and not the index
-    pub fn sign_lamport_bit_by_index(
+    /*  if this method is used directly, its the responsibility of the caller to check that the message bits lenght
+        is equal to the one specified in the public key, otherwise we are signing with a virtually extended key
+    */
+    fn sign_lamport_bit_by_index(
         &self,
         message_bit: bool,
         key_type: LamportType,
@@ -2142,7 +2182,7 @@ mod tests {
         errors::{KeyManagerError, WinternitzError},
         key_store::KeyStore,
         key_type::BitcoinKeyType,
-        lamport::{Lamport, LamportType},
+        lamport::{Lamport, LamportPrivateKey, LamportType},
         rsa::RSAKeyPair,
         verifier::SignatureVerifier,
         winternitz::{to_checksummed_message, WinternitzType},
@@ -7208,26 +7248,26 @@ mod tests {
             let lamport = Lamport::new();
             let mut rng = rand::thread_rng();
 
-            // Generate a master secret
-            let mut master_secret = [0u8; 32];
-            rng.fill_bytes(&mut master_secret);
-
-            // Generate a key for a single bit
-            let private_key =
-                lamport.generate_private_key(&master_secret, LamportType::SHA256, 1, 0)?;
-
-            // Extract bytes from private key for import
-            let (bytes_0s, bytes_1s) = private_key.to_bytes_splitted();
-
-            let public_key = key_manager.import_lamport_private_key(
-                &bytes_0s,
-                &bytes_1s,
-                1,
-                LamportType::SHA256,
-            )?;
-
-            // Test signing both bit values
+            // Test signing both bit values - each needs a separate key since imported keys can only be used once
             for bit_value in [false, true] {
+                // Generate a master secret
+                let mut master_secret = [0u8; 32];
+                rng.fill_bytes(&mut master_secret);
+
+                // Generate a key for a single bit
+                let private_key =
+                    lamport.generate_private_key(&master_secret, LamportType::SHA256, 1, 0)?;
+
+                // Extract bytes from private key for import
+                let (bytes_0s, bytes_1s) = private_key.to_bytes_splitted();
+
+                let public_key = key_manager.import_lamport_private_key(
+                    &bytes_0s,
+                    &bytes_1s,
+                    1,
+                    LamportType::SHA256,
+                )?;
+
                 let signature = key_manager.sign_lamport_bit_by_pubkey(bit_value, &public_key)?;
 
                 assert_eq!(
@@ -7258,12 +7298,23 @@ mod tests {
             let mut master_secret = [0u8; 32];
             rng.fill_bytes(&mut master_secret);
 
-            // Generate a key but don't import it
-            let private_key =
+            // Generate a temporary key to get the bytes
+            let temp_private_key =
                 lamport.generate_private_key(&master_secret, LamportType::SHA256, 256, 0)?;
+            let (bytes_0s, bytes_1s) = temp_private_key.to_bytes_splitted();
+
+            // Create an imported key (imported = true) but DON'T import it into the key manager
+            let private_key = LamportPrivateKey::from_bytes_splitted(
+                &bytes_0s,
+                &bytes_1s,
+                256,
+                LamportType::SHA256,
+                None, // derivation_index: None for imported keys
+                true, // imported: true
+            )?;
             let public_key = private_key.public_key()?;
 
-            // Try to sign with a non-imported key
+            // Try to sign with an imported key that's not in the key manager
             let message_bits = vec![true; 256];
             let result = key_manager.sign_lamport_message_by_pubkey(&message_bits, &public_key);
 
@@ -7568,16 +7619,27 @@ mod tests {
 
     #[test]
     fn test_lamport_deterministic_derivation() -> Result<(), KeyManagerError> {
-        // Create two separate key managers with the same config
-        let result1 = run_test_with_key_manager(|key_manager1| {
-            let public_key1 = key_manager1.next_lamport(256, LamportType::SHA256)?;
-            Ok(public_key1.to_bytes())
-        })?;
+        let keystore_path1 = temp_storage();
+        let keystore_storage_config1 = database_keystore_config(&keystore_path1)?;
 
-        let result2 = run_test_with_key_manager(|key_manager2| {
+        // Create first key manager and derive a key at index 0
+        let result1 = {
+            let key_manager1 = test_deterministic_key_manager(keystore_storage_config1)?;
+            let public_key1 = key_manager1.next_lamport(256, LamportType::SHA256)?;
+            public_key1.to_bytes()
+        };
+        // Drop key_manager1 and cleanup storage
+        cleanup_storage(&keystore_path1);
+
+        // Create second key manager with fresh storage (so index resets to 0)
+        let keystore_path2 = temp_storage();
+        let keystore_storage_config2 = database_keystore_config(&keystore_path2)?;
+        let result2 = {
+            let key_manager2 = test_deterministic_key_manager(keystore_storage_config2)?;
             let public_key2 = key_manager2.next_lamport(256, LamportType::SHA256)?;
-            Ok(public_key2.to_bytes())
-        })?;
+            public_key2.to_bytes()
+        };
+        cleanup_storage(&keystore_path2);
 
         // Both should derive the same key for index 0
         assert_eq!(
@@ -7697,31 +7759,44 @@ mod tests {
     fn test_lamport_error_sign_with_invalid_message_length() -> Result<(), KeyManagerError> {
         run_test_with_key_manager(|key_manager| {
             // Derive a key for 256-bit messages
-            let _public_key = key_manager.next_lamport(256, LamportType::SHA256)?;
+            let public_key = key_manager.next_lamport(256, LamportType::SHA256)?;
 
             // Try to sign a message with wrong bit length (128 bits instead of 256)
             let wrong_message = vec![true; 128];
-            let result =
-                key_manager.sign_lamport_message_by_index(&wrong_message, LamportType::SHA256, 0);
+            let result = key_manager.sign_lamport_message_by_pubkey(&wrong_message, &public_key);
 
+            // Should fail with MessageLengthMismatch error
             assert!(result.is_err(), "Should fail with wrong message length");
+            match result {
+                Err(KeyManagerError::LamportGenerationError(
+                    crate::errors::LamportError::MessageLengthMismatch(actual, expected),
+                )) => {
+                    assert_eq!(actual, 128, "Actual message length should be 128");
+                    assert_eq!(expected, 256, "Expected message length should be 256");
+                }
+                _ => panic!("Expected MessageLengthMismatch error"),
+            }
 
             Ok(())
         })
     }
 
     #[test]
-    fn test_lamport_error_sign_with_invalid_index() -> Result<(), KeyManagerError> {
+    fn test_lamport_sign_with_jumped_index() -> Result<(), KeyManagerError> {
         run_test_with_key_manager(|key_manager| {
             // Derive only one key (index 0)
             let _public_key = key_manager.next_lamport(256, LamportType::SHA256)?;
 
-            // Try to sign with non-existent index
+            // Sign with "jumped" index 99 - this should work for recovery scenarios
+            // where keys were derived in a different storage instance with same mnemonic
             let message_bits = vec![true; 256];
             let result =
                 key_manager.sign_lamport_message_by_index(&message_bits, LamportType::SHA256, 99);
 
-            assert!(result.is_err(), "Should fail with invalid index");
+            assert!(
+                result.is_ok(),
+                "Should allow signing with jumped index for recovery"
+            );
 
             Ok(())
         })

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -349,19 +349,30 @@ impl KeyManager {
         Ok(rsa_pubkey_pem)
     }
 
-    // TODO is this import practical to final user?
     pub fn import_lamport_private_key(
         &self,
-        private_key: &LamportPrivateKey,
+        bytes_0s: &[u8],
+        bytes_1s: &[u8],
+        message_bit_length: usize,
+        hash_type: LamportType,
     ) -> Result<LamportPublicKey, KeyManagerError> {
         // Returns the corresponding public key
 
-        // TODO set imported to true
+        // Create private key from bytes with imported flag set to true
+        let private_key = LamportPrivateKey::from_bytes_splitted(
+            bytes_0s,
+            bytes_1s,
+            message_bit_length,
+            hash_type,
+            None, // derivation_index: None for imported keys
+            true, // imported: true
+        )?;
+
+        // Get the corresponding public key
         let public_key = private_key.public_key()?;
-        self.keystore.store_lamport_imported_key(private_key, &public_key)?;
+
         // store the lamport keys in a way that we can retrieve them for signing
-        // TODO mark them as used after signing to prevent reuse, ambiguous for imports. we don't know if it was already used before importing???
-        // TODO for imports also track if already used to signpublic_key, even if we don't know its past (discussed with Martin)
+        self.keystore.store_lamport_imported_key(&private_key, &public_key)?;
 
         Ok(public_key)
     }
@@ -7119,9 +7130,16 @@ mod tests {
                 )?;
                 let original_public_key = private_key.public_key()?;
 
+                // Extract bytes from private key for import
+                let (bytes_0s, bytes_1s) = private_key.to_bytes_splitted();
+
                 // Import the key into the key manager
-                let imported_public_key =
-                    key_manager.import_lamport_private_key(&private_key)?;
+                let imported_public_key = key_manager.import_lamport_private_key(
+                    &bytes_0s,
+                    &bytes_1s,
+                    message_bit_length,
+                    hash_type,
+                )?;
 
                 // Verify the imported public key matches
                 assert_eq!(
@@ -7180,7 +7198,16 @@ mod tests {
             // Test SHA256 with 32-byte message (typical hash digest)
             let private_key =
                 lamport.generate_private_key(&master_secret, LamportType::SHA256, 256, 0)?;
-            let public_key = key_manager.import_lamport_private_key(&private_key)?;
+
+            // Extract bytes from private key for import
+            let (bytes_0s, bytes_1s) = private_key.to_bytes_splitted();
+
+            let public_key = key_manager.import_lamport_private_key(
+                &bytes_0s,
+                &bytes_1s,
+                256,
+                LamportType::SHA256,
+            )?;
 
             // Sign a 32-byte message (simulating a SHA-256 hash)
             let mut message_bytes = [0u8; 32];
@@ -7211,7 +7238,16 @@ mod tests {
 
             // Generate a key for a single bit
             let private_key = lamport.generate_private_key(&master_secret, LamportType::SHA256, 1, 0)?;
-            let public_key = key_manager.import_lamport_private_key(&private_key)?;
+
+            // Extract bytes from private key for import
+            let (bytes_0s, bytes_1s) = private_key.to_bytes_splitted();
+
+            let public_key = key_manager.import_lamport_private_key(
+                &bytes_0s,
+                &bytes_1s,
+                1,
+                LamportType::SHA256,
+            )?;
 
             // Test signing both bit values
             for bit_value in [false, true] {
@@ -7287,7 +7323,16 @@ mod tests {
 
                 let private_key =
                     lamport.generate_private_key(&master_secret, LamportType::SHA256, 256, i)?;
-                let public_key = key_manager.import_lamport_private_key(&private_key)?;
+
+                // Extract bytes from private key for import
+                let (bytes_0s, bytes_1s) = private_key.to_bytes_splitted();
+
+                let public_key = key_manager.import_lamport_private_key(
+                    &bytes_0s,
+                    &bytes_1s,
+                    256,
+                    LamportType::SHA256,
+                )?;
                 keys.push((private_key, public_key));
             }
 
@@ -7473,7 +7518,16 @@ mod tests {
 
             let private_key =
                 lamport.generate_private_key(&master_secret, LamportType::SHA256, 256, 0)?;
-            let public_key = key_manager.import_lamport_private_key(&private_key)?;
+
+            // Extract bytes from private key for import
+            let (bytes_0s, bytes_1s) = private_key.to_bytes_splitted();
+
+            let public_key = key_manager.import_lamport_private_key(
+                &bytes_0s,
+                &bytes_1s,
+                256,
+                LamportType::SHA256,
+            )?;
 
             // Sign once - should succeed
             let message_bits = vec![true; 256];
@@ -7615,7 +7669,16 @@ mod tests {
             rng.fill_bytes(&mut master_secret);
             let private_key =
                 lamport.generate_private_key(&master_secret, LamportType::SHA256, 256, 0)?;
-            let imported_key = key_manager.import_lamport_private_key(&private_key)?;
+
+            // Extract bytes from private key for import
+            let (bytes_0s, bytes_1s) = private_key.to_bytes_splitted();
+
+            let imported_key = key_manager.import_lamport_private_key(
+                &bytes_0s,
+                &bytes_1s,
+                256,
+                LamportType::SHA256,
+            )?;
 
             // Derive another key
             let derived_key2 = key_manager.next_lamport(256, LamportType::SHA256)?;

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -7955,7 +7955,7 @@ mod tests {
             use crate::lamport::HashFunction;
 
             let message_bit_length = 128;
-            let public_key =
+            let _public_key =
                 key_manager.next_lamport(message_bit_length, LamportType::HASH160)?;
 
             let message_bits = vec![true; message_bit_length];

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -349,14 +349,16 @@ impl KeyManager {
         Ok(rsa_pubkey_pem)
     }
 
+    // TODO is this import practical to final user?
     pub fn import_lamport_private_key(
         &self,
         private_key: &LamportPrivateKey,
     ) -> Result<LamportPublicKey, KeyManagerError> {
         // Returns the corresponding public key
 
+        // TODO set imported to true
         let public_key = private_key.public_key()?;
-        self.keystore.store_lamport_key(private_key, &public_key)?;
+        self.keystore.store_lamport_imported_key(private_key, &public_key)?;
         // store the lamport keys in a way that we can retrieve them for signing
         // TODO mark them as used after signing to prevent reuse, ambiguous for imports. we don't know if it was already used before importing???
         // TODO for imports also track if already used to signpublic_key, even if we don't know its past (discussed with Martin)
@@ -1434,18 +1436,90 @@ impl KeyManager {
         message_bits: &[bool],
         public_key: &LamportPublicKey,
     ) -> Result<LamportSignature, KeyManagerError> {
-        // TODO do this if its imported key if not use by index
-        let private_key = self
-            .keystore
-            .load_lamport_key(public_key)?
-            .ok_or(KeyManagerError::LamportKeyNotFound)?;
 
-        let lamport = Lamport::new();
-        let sig = lamport.sign_message(message_bits, &private_key)?;
-        Ok(sig)
+        if public_key.imported(){
+            self.sign_lamport_message_by_pubkey_imported(message_bits, public_key)
+        }
+        else {
+            let index = public_key.derivation_index()
+                .ok_or(KeyManagerError::LamportKeyDerivationIndexNotFound)?;
+            self.sign_lamport_message_by_index(
+                message_bits,
+                public_key.hash_type(),
+                index,
+            )
+        }
+
     }
 
-    // TODO add ign_lamport_message_by_index
+    // private
+    fn sign_lamport_message_by_pubkey_imported(
+        &self,
+        message_bits: &[bool],
+        public_key: &LamportPublicKey,
+    ) -> Result<LamportSignature, KeyManagerError> {
+            let private_key = self
+                .keystore
+                .load_lamport_imported_key(public_key)?
+                .ok_or(KeyManagerError::LamportKeyNotFound)?;
+
+            let tx_id = self.begin_transaction();
+            // check if index was already used, if its error, if not mark and save
+            #[cfg(feature = "lamport_idx_check")]
+            match self
+                .keystore
+                .check_and_mark_lamport_used_imported(public_key, tx_id)
+            {
+                Ok(()) => {}
+                Err(e) => {
+                    self.rollback_transaction(tx_id)?;
+                    return Err(e);
+                }
+            }
+
+            let lamport = Lamport::new();
+            let sig = lamport.sign_message(message_bits, &private_key)?;
+
+            self.commit_transaction(tx_id)?;
+            Ok(sig)
+    }
+
+    // For one-time lamport keys
+    pub fn sign_lamport_message_by_index(
+        &self,
+        message_bits: &[bool],
+        key_type: LamportType,
+        index: u32,
+    ) -> Result<LamportSignature, KeyManagerError> {
+        let master_secret = self.keystore.load_lamport_seed()?;
+        let lamport = Lamport::new();
+        let private_key = lamport.generate_private_key(
+            &*master_secret,
+            key_type,
+            message_bits.len(),
+            index,
+        )?;
+
+        let tx_id = self.begin_transaction();
+
+        // check if index was already used, if its error, if not mark and save
+        #[cfg(feature = "lamport_idx_check")]
+        match self
+            .keystore
+            .check_and_mark_lamport_index_used_derivated(index, tx_id)
+        {
+            Ok(()) => {}
+            Err(e) => {
+                self.rollback_transaction(tx_id)?;
+                return Err(e);
+            }
+        }
+
+        let signature = lamport.sign_message(message_bits, &private_key)?;
+
+        self.commit_transaction(tx_id)?;
+        Ok(signature)
+    }
 
     /// Sign a message from bytes
     ///
@@ -1467,18 +1541,88 @@ impl KeyManager {
         message_bytes: &[u8],
         public_key: &LamportPublicKey,
     ) -> Result<LamportSignature, KeyManagerError> {
-        // TODO do this if its imported key if not use by index
-        let private_key = self
-            .keystore
-            .load_lamport_key(public_key)?
-            .ok_or(KeyManagerError::LamportKeyNotFound)?;
-
-        let lamport = Lamport::new();
-        let sig = lamport.sign_message_bytes(message_bytes, &private_key)?;
-        Ok(sig)
+        if public_key.imported(){
+            self.sign_lamport_message_bytes_by_pubkey_imported(message_bytes, public_key)
+        }
+        else {
+            let index = public_key.derivation_index()
+                .ok_or(KeyManagerError::LamportKeyDerivationIndexNotFound)?;
+            self.sign_lamport_message_bytes_by_index(
+                message_bytes,
+                public_key.hash_type(),
+                index,
+            )
+        }
     }
 
-    // TODO add sign_lamport_message_bytes_by_index
+    // private
+    fn sign_lamport_message_bytes_by_pubkey_imported(
+        &self,
+        message_bytes: &[u8],
+        public_key: &LamportPublicKey,
+    ) -> Result<LamportSignature, KeyManagerError> {
+            let private_key = self
+                .keystore
+                .load_lamport_imported_key(public_key)?
+                .ok_or(KeyManagerError::LamportKeyNotFound)?;
+
+            let tx_id = self.begin_transaction();
+            // check if index was already used, if its error, if not mark and save
+            #[cfg(feature = "lamport_idx_check")]
+            match self
+                .keystore
+                .check_and_mark_lamport_used_imported(public_key, tx_id)
+            {
+                Ok(()) => {}
+                Err(e) => {
+                    self.rollback_transaction(tx_id)?;
+                    return Err(e);
+                }
+            }
+
+            let lamport = Lamport::new();
+            let sig = lamport.sign_message_bytes(message_bytes, &private_key)?;
+
+            self.commit_transaction(tx_id)?;
+            Ok(sig)
+    }
+
+    // For one-time lamport keys
+    pub fn sign_lamport_message_bytes_by_index(
+        &self,
+        message_bytes: &[u8],
+        key_type: LamportType,
+        index: u32,
+    ) -> Result<LamportSignature, KeyManagerError> {
+        let master_secret = self.keystore.load_lamport_seed()?;
+        let lamport = Lamport::new();
+        let private_key = lamport.generate_private_key(
+            &*master_secret,
+            key_type,
+            message_bytes.len() * 8,  // Convert bytes to bits
+            index,
+        )?;
+
+        let tx_id = self.begin_transaction();
+
+        // check if index was already used, if its error, if not mark and save
+        #[cfg(feature = "lamport_idx_check")]
+        match self
+            .keystore
+            .check_and_mark_lamport_index_used_derivated(index, tx_id)
+        {
+            Ok(()) => {}
+            Err(e) => {
+                self.rollback_transaction(tx_id)?;
+                return Err(e);
+            }
+        }
+
+        let signature = lamport.sign_message_bytes(message_bytes, &private_key)?;
+
+        self.commit_transaction(tx_id)?;
+        Ok(signature)
+    }
 
     /// Sign a single bit
     ///
@@ -1499,18 +1643,88 @@ impl KeyManager {
         message_bit: bool, // bool representing a bit false = 0, true = 1
         public_key: &LamportPublicKey,
     ) -> Result<LamportSignature, KeyManagerError> {
-        // TODO do this if its imported key if not use by index
-        let private_key = self
-            .keystore
-            .load_lamport_key(public_key)?
-            .ok_or(KeyManagerError::LamportKeyNotFound)?;
-
-        let lamport = Lamport::new();
-        let sig = lamport.sign_message_bit(message_bit, &private_key)?;
-        Ok(sig)
+        if public_key.imported(){
+            self.sign_lamport_bit_by_pubkey_imported(message_bit, public_key)
+        }
+        else {
+            let index = public_key.derivation_index()
+                .ok_or(KeyManagerError::LamportKeyDerivationIndexNotFound)?;
+            self.sign_lamport_bit_by_index(
+                message_bit,
+                public_key.hash_type(),
+                index,
+            )
+        }
     }
 
-    // TODO add sign_lamport_bit_by_pubkey
+    // private
+    fn sign_lamport_bit_by_pubkey_imported(
+        &self,
+        message_bit: bool, // bool representing a bit false = 0, true = 1
+        public_key: &LamportPublicKey,
+    ) -> Result<LamportSignature, KeyManagerError> {
+            let private_key = self
+                .keystore
+                .load_lamport_imported_key(public_key)?
+                .ok_or(KeyManagerError::LamportKeyNotFound)?;
+
+            let tx_id = self.begin_transaction();
+            // check if index was already used, if its error, if not mark and save
+            #[cfg(feature = "lamport_idx_check")]
+            match self
+                .keystore
+                .check_and_mark_lamport_used_imported(public_key, tx_id)
+            {
+                Ok(()) => {}
+                Err(e) => {
+                    self.rollback_transaction(tx_id)?;
+                    return Err(e);
+                }
+            }
+
+            let lamport = Lamport::new();
+            let sig = lamport.sign_message_bit(message_bit, &private_key)?;
+
+            self.commit_transaction(tx_id)?;
+            Ok(sig)
+    }
+
+    // For one-time lamport keys
+    pub fn sign_lamport_bit_by_index(
+        &self,
+        message_bit: bool,
+        key_type: LamportType,
+        index: u32,
+    ) -> Result<LamportSignature, KeyManagerError> {
+        let master_secret = self.keystore.load_lamport_seed()?;
+        let lamport = Lamport::new();
+        let private_key = lamport.generate_private_key(
+            &*master_secret,
+            key_type,
+            1,  // Single bit
+            index,
+        )?;
+
+        let tx_id = self.begin_transaction();
+
+        // check if index was already used, if its error, if not mark and save
+        #[cfg(feature = "lamport_idx_check")]
+        match self
+            .keystore
+            .check_and_mark_lamport_index_used_derivated(index, tx_id)
+        {
+            Ok(()) => {}
+            Err(e) => {
+                self.rollback_transaction(tx_id)?;
+                return Err(e);
+            }
+        }
+
+        let signature = lamport.sign_message_bit(message_bit, &private_key)?;
+
+        self.commit_transaction(tx_id)?;
+        Ok(signature)
+    }
 
     // TODO write examples
     // TODO mark imported used (similar to Winternitz)

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -7234,7 +7234,7 @@ mod tests {
 
             // Verify the signature
             assert!(
-                lamport.verify_signature_bytes(&message_bytes, &signature, &public_key)?,
+                lamport.verify_signature(&message_bytes, &signature, &public_key)?,
                 "Byte signature verification should succeed"
             );
 
@@ -7278,7 +7278,7 @@ mod tests {
 
                 // Verify the signature
                 assert!(
-                    lamport.verify_signature_bit(bit_value, &signature, &public_key)?,
+                    lamport.verify_signature(bit_value, &signature, &public_key)?,
                     "Single bit signature verification should succeed for bit={}",
                     bit_value
                 );
@@ -7474,7 +7474,7 @@ mod tests {
             )?;
 
             // Verify signature
-            assert!(lamport.verify_signature_bytes(&message_bytes, &signature, &public_keys[0])?);
+            assert!(lamport.verify_signature(&message_bytes, &signature, &public_keys[0])?);
 
             Ok(())
         })
@@ -7491,12 +7491,12 @@ mod tests {
             // Sign bit 0 using index 0
             let signature_0 =
                 key_manager.sign_lamport_bit_by_index(false, LamportType::SHA256, 0)?;
-            assert!(lamport.verify_signature_bit(false, &signature_0, &public_keys[0])?);
+            assert!(lamport.verify_signature(false, &signature_0, &public_keys[0])?);
 
             // Sign bit 1 using index 1
             let signature_1 =
                 key_manager.sign_lamport_bit_by_index(true, LamportType::SHA256, 1)?;
-            assert!(lamport.verify_signature_bit(true, &signature_1, &public_keys[1])?);
+            assert!(lamport.verify_signature(true, &signature_1, &public_keys[1])?);
 
             Ok(())
         })
@@ -7867,7 +7867,7 @@ mod tests {
                 )?;
 
                 assert!(
-                    lamport.verify_signature_bytes(&message_bytes, &signature, &public_key)?,
+                    lamport.verify_signature(&message_bytes, &signature, &public_key)?,
                     "Byte size {} should work correctly",
                     byte_size
                 );
@@ -7907,7 +7907,7 @@ mod tests {
             // Verify all wire signatures
             for i in 0..wire_count {
                 assert!(
-                    lamport.verify_signature_bit(
+                    lamport.verify_signature(
                         wire_values[i as usize],
                         &signatures[i as usize],
                         &wire_keys[i as usize]
@@ -7918,7 +7918,7 @@ mod tests {
 
                 // Verify that wrong bit value fails
                 assert!(
-                    !lamport.verify_signature_bit(
+                    !lamport.verify_signature(
                         !wire_values[i as usize],
                         &signatures[i as usize],
                         &wire_keys[i as usize]

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -1733,6 +1733,7 @@ mod tests {
         errors::{KeyManagerError, WinternitzError},
         key_store::KeyStore,
         key_type::BitcoinKeyType,
+        lamport::{Lamport, LamportType},
         rsa::RSAKeyPair,
         verifier::SignatureVerifier,
         winternitz::{to_checksummed_message, WinternitzType},
@@ -6650,5 +6651,223 @@ mod tests {
 
         cleanup_storage(&keystore_path);
         Ok(())
+    }
+
+    #[test]
+    fn test_lamport_import_store_sign_load_cycle() -> Result<(), KeyManagerError> {
+        run_test_with_key_manager(|key_manager| {
+            let lamport = Lamport::new();
+            let mut rng = rand::thread_rng();
+
+            // Test with different hash types and message lengths
+            let test_cases = vec![
+                (LamportType::SHA256, 256),
+                (LamportType::HASH160, 160),
+                (LamportType::RIPEMD160, 128),
+                (LamportType::HASH256, 256),
+            ];
+
+            for (hash_type, message_bit_length) in test_cases {
+                // Generate a master secret
+                let mut master_secret = [0u8; 32];
+                rng.fill_bytes(&mut master_secret);
+
+                // Generate a Lamport key
+                let private_key = lamport.generate_private_key(
+                    &master_secret,
+                    hash_type,
+                    message_bit_length,
+                    0,
+                )?;
+                let original_public_key = private_key.public_key()?;
+
+                // Import the key into the key manager
+                let imported_public_key =
+                    key_manager.import_lamport_private_key(&private_key)?;
+
+                // Verify the imported public key matches
+                assert_eq!(
+                    original_public_key.to_bytes(),
+                    imported_public_key.to_bytes(),
+                    "Imported public key should match for {:?}",
+                    hash_type
+                );
+
+                // Create a message to sign
+                let message_bits: Vec<bool> = (0..message_bit_length)
+                    .map(|_| (rng.next_u32() % 2) == 1)
+                    .collect();
+
+                // Sign the message using the imported key
+                let signature = key_manager.sign_lamport_message_by_pubkey(
+                    &message_bits,
+                    &imported_public_key,
+                )?;
+
+                // Verify the signature
+                assert!(
+                    lamport.verify_signature(&message_bits, &signature, &imported_public_key)?,
+                    "Signature verification should succeed for {:?}",
+                    hash_type
+                );
+
+                // Verify signature properties
+                assert_eq!(
+                    signature.message_bit_length(),
+                    message_bit_length,
+                    "Signature message length should match for {:?}",
+                    hash_type
+                );
+                assert_eq!(
+                    signature.hash_type(),
+                    hash_type,
+                    "Signature hash type should match"
+                );
+            }
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_lamport_sign_bytes_roundtrip() -> Result<(), KeyManagerError> {
+        run_test_with_key_manager(|key_manager| {
+            let lamport = Lamport::new();
+            let mut rng = rand::thread_rng();
+
+            // Generate a master secret
+            let mut master_secret = [0u8; 32];
+            rng.fill_bytes(&mut master_secret);
+
+            // Test SHA256 with 32-byte message (typical hash digest)
+            let private_key =
+                lamport.generate_private_key(&master_secret, LamportType::SHA256, 256, 0)?;
+            let public_key = key_manager.import_lamport_private_key(&private_key)?;
+
+            // Sign a 32-byte message (simulating a SHA-256 hash)
+            let mut message_bytes = [0u8; 32];
+            rng.fill_bytes(&mut message_bytes);
+
+            let signature =
+                key_manager.sign_lamport_message_bytes_by_pubkey(&message_bytes, &public_key)?;
+
+            // Verify the signature
+            assert!(
+                lamport.verify_signature_bytes(&message_bytes, &signature, &public_key)?,
+                "Byte signature verification should succeed"
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_lamport_sign_single_bit() -> Result<(), KeyManagerError> {
+        run_test_with_key_manager(|key_manager| {
+            let lamport = Lamport::new();
+            let mut rng = rand::thread_rng();
+
+            // Generate a master secret
+            let mut master_secret = [0u8; 32];
+            rng.fill_bytes(&mut master_secret);
+
+            // Generate a key for a single bit
+            let private_key = lamport.generate_private_key(&master_secret, LamportType::SHA256, 1, 0)?;
+            let public_key = key_manager.import_lamport_private_key(&private_key)?;
+
+            // Test signing both bit values
+            for bit_value in [false, true] {
+                let signature =
+                    key_manager.sign_lamport_bit_by_pubkey(bit_value, &public_key)?;
+
+                assert_eq!(
+                    signature.message_bit_length(),
+                    1,
+                    "Signature should be for 1 bit"
+                );
+
+                // Verify the signature
+                assert!(
+                    lamport.verify_signature_bit(bit_value, &signature, &public_key)?,
+                    "Single bit signature verification should succeed for bit={}",
+                    bit_value
+                );
+            }
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_lamport_key_not_found_error() -> Result<(), KeyManagerError> {
+        run_test_with_key_manager(|key_manager| {
+            let lamport = Lamport::new();
+            let mut rng = rand::thread_rng();
+
+            // Generate a master secret
+            let mut master_secret = [0u8; 32];
+            rng.fill_bytes(&mut master_secret);
+
+            // Generate a key but don't import it
+            let private_key =
+                lamport.generate_private_key(&master_secret, LamportType::SHA256, 256, 0)?;
+            let public_key = private_key.public_key()?;
+
+            // Try to sign with a non-imported key
+            let message_bits = vec![true; 256];
+            let result = key_manager.sign_lamport_message_by_pubkey(&message_bits, &public_key);
+
+            assert!(
+                result.is_err(),
+                "Should fail to sign with non-imported key"
+            );
+
+            if let Err(KeyManagerError::LamportKeyNotFound) = result {
+                // Expected error
+            } else {
+                panic!("Expected LamportKeyNotFound error");
+            }
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_lamport_storage_key_uniqueness() -> Result<(), KeyManagerError> {
+        run_test_with_key_manager(|key_manager| {
+            let lamport = Lamport::new();
+            let mut rng = rand::thread_rng();
+
+            // Generate multiple keys and ensure they can all be stored and retrieved
+            let num_keys = 10;
+            let mut keys = Vec::new();
+
+            for i in 0..num_keys {
+                // Generate a unique master secret for each key
+                let mut master_secret = [0u8; 32];
+                rng.fill_bytes(&mut master_secret);
+
+                let private_key =
+                    lamport.generate_private_key(&master_secret, LamportType::SHA256, 256, i)?;
+                let public_key = key_manager.import_lamport_private_key(&private_key)?;
+                keys.push((private_key, public_key));
+            }
+
+            // Verify all keys can be retrieved and used for signing
+            for (_original_private, public_key) in keys.iter() {
+                let message_bits: Vec<bool> =
+                    (0..256).map(|i| (i % 2) == 0).collect();
+
+                let signature =
+                    key_manager.sign_lamport_message_by_pubkey(&message_bits, public_key)?;
+
+                assert!(
+                    lamport.verify_signature(&message_bits, &signature, public_key)?,
+                    "All stored keys should be retrievable and functional"
+                );
+            }
+
+            Ok(())
+        })
     }
 }

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -7299,6 +7299,8 @@ mod tests {
             // Derive keys for single-bit signing
             let public_keys = key_manager.next_multiple_lamport(1, LamportType::SHA256, 2)?;
 
+            assert!(public_keys[0].derivation_index().unwrap() + 1 == public_keys[1].derivation_index().unwrap());
+
             // Sign bit 0 using index 0
             let signature_0 =
                 key_manager.sign_lamport_message_by_index(false, LamportType::SHA256, 0)?;

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -21,7 +21,7 @@ use crate::{
     errors::KeyManagerError,
     key_store::KeyStore,
     key_type::BitcoinKeyType,
-    lamport::{Lamport, LamportPrivateKey, LamportPublicKey, LamportSignature},
+    lamport::{Lamport, LamportPrivateKey, LamportPublicKey, LamportSignature, LamportType},
     musig2::{
         errors::Musig2SignerError,
         musig::{MuSig2Signer, MuSig2SignerApi},
@@ -195,6 +195,32 @@ impl KeyManager {
             Err(KeyManagerError::WinternitzSeedNotFound) => {
                 // No Winternitz seed stored, generate and store it
                 keystore.store_winternitz_seed(expected_winternitz_seed)?;
+            }
+            Err(e) => return Err(e), // Propagate storage/decryption errors
+        }
+
+        // Validate or generate Lamport seed - similar to key derivation seed validation
+        // The Lamport seed is derived from the key derivation seed, so we validate it to detect corruption.
+        let expected_lamport_seed = {
+            let key_derivation_seed = keystore.load_key_derivation_seed()?;
+            Self::derive_lamport_master_seed(
+                secp.clone(),
+                &*key_derivation_seed,
+                network,
+                Self::ACCOUNT_DERIVATION_INDEX,
+            )?
+        };
+
+        match keystore.load_lamport_seed() {
+            Ok(stored_lamport_seed) => {
+                // Validate that the stored Lamport seed matches what would be derived from key derivation seed
+                if *stored_lamport_seed != *expected_lamport_seed {
+                    return Err(KeyManagerError::CorruptedLamportSeed);
+                }
+            }
+            Err(KeyManagerError::LamportSeedNotFound) => {
+                // No Lamport seed stored, generate and store it
+                keystore.store_lamport_seed(expected_lamport_seed)?;
             }
             Err(e) => return Err(e), // Propagate storage/decryption errors
         }
@@ -499,6 +525,36 @@ impl KeyManager {
         let secret_32_bytes = Zeroizing::new(account_xpriv.private_key.secret_bytes());
 
         // Return the private key bytes as master seed for Winternitz
+        Ok(secret_32_bytes)
+    }
+
+    // Lamport uses BIP-39/BIP-44 style derivation with a hardened custom purpose path for lamport:
+    fn derive_lamport_master_seed(
+        secp: secp256k1::Secp256k1<All>,
+        key_derivation_seed: &[u8],
+        network: Network,
+        account: u32,
+    ) -> Result<Zeroizing<[u8; 32]>, KeyManagerError> {
+        // Dev note: Using coin type as it's nice to differentiate by network, lamport are OT,
+        // so they should not be repeated across different networks, to avoid a kind of "take from testnet and use in mainnet" attack
+        let lamport_full_derivation_path = Self::build_bip44_derivation_path(
+            Self::LAMPORT_PURPOSE_INDEX,
+            Self::get_bitcoin_coin_type_by_network(network),
+            account,
+            Self::CHANGE_DERIVATION_INDEX,
+            0, // index does not matter here
+        );
+
+        let hardened_lamport_account_derivation_path =
+            Self::extract_account_level_path(&lamport_full_derivation_path);
+
+        let master_xpriv = Xpriv::new_master(network, &key_derivation_seed)?;
+        let account_xpriv =
+            master_xpriv.derive_priv(&secp, &hardened_lamport_account_derivation_path)?;
+
+        let secret_32_bytes = Zeroizing::new(account_xpriv.private_key.secret_bytes());
+
+        // Return the private key bytes as master seed for Lamport
         Ok(secret_32_bytes)
     }
 
@@ -910,6 +966,141 @@ impl KeyManager {
         Ok(pubkeys)
     }
 
+    /// Derives a Lamport OT key at a specific derivation index using BIP-39/BIP-44 hierarchical deterministic (HD) derivation.
+    ///
+    /// ** Usage of this function is discouraged in favor of [`next_lamport`](Self::next_lamport) instead. **
+    ///
+    /// The `next_lamport` function provides a secure index management by automatically tracking
+    /// the next available derivation index, preventing accidental key reuse and simplifying
+    /// key generation workflows.
+    ///
+    fn derive_lamport(
+        &self,
+        message_bit_length: usize,
+        key_type: LamportType,
+        index: u32,
+    ) -> Result<crate::lamport::LamportPublicKey, KeyManagerError> {
+        let master_secret = self.keystore.load_lamport_seed()?;
+
+        let lamport = crate::lamport::Lamport::new();
+        let public_key = lamport.generate_public_key(
+            &*master_secret,
+            key_type,
+            message_bit_length,
+            index,
+        )?;
+
+        Ok(public_key)
+    }
+
+    /// Generates the next Lamport OT key in sequence using automatic index management and BIP-39/BIP-44 HD derivation.
+    ///
+    /// This is the **recommended** function for Lamport key generation as it provides automatic index management,
+    /// preventing accidental key reuse and simplifying key generation workflows compared to [`derive_lamport`](Self::derive_lamport).
+    ///
+    /// The function automatically tracks and increments the derivation index for each Lamport type and message bit length combination, ensuring that:
+    /// - Each call generates a unique Lamport key
+    /// - No derivation indices are accidentally reused
+    /// - The sequence of generated keys is deterministic and recoverable
+    /// - Different message bit lengths for the same Lamport type have separate index counters
+    ///
+    pub fn next_lamport(
+        &self,
+        message_bit_length: usize,
+        key_type: LamportType,
+    ) -> Result<crate::lamport::LamportPublicKey, KeyManagerError> {
+        // Dev note: Only the index increment is transactional to minimize database lock time.
+        // if key derivation fails, the index is wasted, this is not an issue in One Time Use keys
+        let index = {
+            let tx_id = self.begin_transaction();
+
+            let index = self.next_lamport_index()?;
+            self.keystore.store_next_lamport_index(index + 1, tx_id)?;
+
+            self.commit_transaction(tx_id)?;
+
+            index
+        };
+
+        let pubkey = self.derive_lamport(message_bit_length, key_type, index)?;
+        Ok(pubkey)
+    }
+
+    fn next_lamport_index(&self) -> Result<u32, KeyManagerError> {
+        match self.keystore.load_next_lamport_index() {
+            Ok(stored_index) => Ok(stored_index),
+            Err(KeyManagerError::NextLamportIndexNotFound) => Ok(Self::STARTING_DERIVATION_INDEX),
+            Err(e) => Err(e), // Propagate other errors (e.g., storage/decryption errors)
+        }
+    }
+
+    /// Derives n Lamport OT key starting at a specific derivation index using BIP-39/BIP-44 hierarchical deterministic (HD) derivation.
+    ///
+    /// ** Usage of this function is discouraged in favor of [`next_multiple_lamport`](Self::next_multiple_lamport) instead. **
+    ///
+    /// The `next_multiple_lamport` function provides a secure index management by automatically tracking
+    /// the next available derivation index, preventing accidental key reuse and simplifying
+    /// key generation workflows.
+    ///
+    fn derive_multiple_lamport(
+        &self,
+        message_bit_length: usize,
+        key_type: LamportType,
+        initial_index: u32,
+        number_of_keys: u32,
+    ) -> Result<Vec<crate::lamport::LamportPublicKey>, KeyManagerError> {
+        let master_secret = self.keystore.load_lamport_seed()?;
+
+        let mut public_keys = Vec::new();
+
+        for index in initial_index..initial_index + number_of_keys {
+            let lamport = crate::lamport::Lamport::new();
+            let public_key = lamport.generate_public_key(
+                &*master_secret,
+                key_type,
+                message_bit_length,
+                index,
+            )?;
+            public_keys.push(public_key);
+        }
+
+        Ok(public_keys)
+    }
+
+    /// Generates the next n Lamport OT keys in sequence using automatic index management and BIP-39/BIP-44 HD derivation.
+    ///
+    /// This is the **recommended** function for Lamport key generation as it provides automatic index management,
+    /// preventing accidental key reuse and simplifying key generation workflows compared to [`derive_multiple_lamport`](Self::derive_multiple_lamport).
+    ///
+    pub fn next_multiple_lamport(
+        &self,
+        message_bit_length: usize,
+        key_type: LamportType,
+        number_of_keys: u32,
+    ) -> Result<Vec<crate::lamport::LamportPublicKey>, KeyManagerError> {
+        // Dev note: Only the index increment is transactional to minimize database lock time.
+        // if key derivation fails, the index is wasted, this is not an issue in One Time Use keys
+        let initial_index = {
+            let tx_id = self.begin_transaction();
+
+            let initial_index = self.next_lamport_index()?;
+            self.keystore
+                .store_next_lamport_index(initial_index + number_of_keys, tx_id)?;
+
+            self.commit_transaction(tx_id)?;
+
+            initial_index
+        };
+
+        let pubkeys = self.derive_multiple_lamport(
+            message_bit_length,
+            key_type,
+            initial_index,
+            number_of_keys,
+        )?;
+        Ok(pubkeys)
+    }
+
     // Dev note: this key is not related to the key derivation seed used for HD wallets
     // In the future we can find a way to securely derive it from a mnemonic too
     pub fn generate_rsa_keypair<R: RngCore + CryptoRng>(
@@ -1243,6 +1434,7 @@ impl KeyManager {
         message_bits: &[bool],
         public_key: &LamportPublicKey,
     ) -> Result<LamportSignature, KeyManagerError> {
+        // TODO do this if its imported key if not use by index
         let private_key = self
             .keystore
             .load_lamport_key(public_key)?
@@ -1252,6 +1444,8 @@ impl KeyManager {
         let sig = lamport.sign_message(message_bits, &private_key)?;
         Ok(sig)
     }
+
+    // TODO add ign_lamport_message_by_index
 
     /// Sign a message from bytes
     ///
@@ -1273,6 +1467,7 @@ impl KeyManager {
         message_bytes: &[u8],
         public_key: &LamportPublicKey,
     ) -> Result<LamportSignature, KeyManagerError> {
+        // TODO do this if its imported key if not use by index
         let private_key = self
             .keystore
             .load_lamport_key(public_key)?
@@ -1282,6 +1477,8 @@ impl KeyManager {
         let sig = lamport.sign_message_bytes(message_bytes, &private_key)?;
         Ok(sig)
     }
+
+    // TODO add sign_lamport_message_bytes_by_index
 
     /// Sign a single bit
     ///
@@ -1302,6 +1499,7 @@ impl KeyManager {
         message_bit: bool, // bool representing a bit false = 0, true = 1
         public_key: &LamportPublicKey,
     ) -> Result<LamportSignature, KeyManagerError> {
+        // TODO do this if its imported key if not use by index
         let private_key = self
             .keystore
             .load_lamport_key(public_key)?
@@ -1312,9 +1510,10 @@ impl KeyManager {
         Ok(sig)
     }
 
-    // TODO add other lamport methods, like generation (based on what winternitz offer)
+    // TODO add sign_lamport_bit_by_pubkey
+
     // TODO write examples
-    // TODO mark used
+    // TODO mark imported used (similar to Winternitz)
     // TODO check lamport extra data
 
     /// Exports the private key for a given public key.

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -63,12 +63,14 @@ impl KeyManager {
         - It adds support for:
             - Taproot keys.
             - Winternitz keys.
+            - Lamport keys.
             - RSA keys.
             - MuSig2 signing.
     */
     const ACCOUNT_DERIVATION_INDEX: u32 = 0; // Account - only one account supported up to now - fixed to 0
     const CHANGE_DERIVATION_INDEX: u32 = 0; // Change (0 for external, 1 for internal) - wont manage change up to now - fixed to 0
     const WINTERNITZ_PURPOSE_INDEX: u32 = 987; // Custom purpose index for Winternitz keys
+    const LAMPORT_PURPOSE_INDEX: u32 = 986; // Custom purpose index for Lamport keys
     const STARTING_DERIVATION_INDEX: u32 = 0; // Starting index for derivation
 
     pub fn new(
@@ -1309,6 +1311,11 @@ impl KeyManager {
         let sig = lamport.sign_message_bit(message_bit, &private_key)?;
         Ok(sig)
     }
+
+    // TODO add other lamport methods, like generation (based on what winternitz offer)
+    // TODO write examples
+    // TODO mark used
+    // TODO check lamport extra data
 
     /// Exports the private key for a given public key.
     ///

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -21,7 +21,9 @@ use crate::{
     errors::KeyManagerError,
     key_store::KeyStore,
     key_type::BitcoinKeyType,
-    lamport::{Lamport, LamportMessage, LamportPrivateKey, LamportPublicKey, LamportSignature, LamportType},
+    lamport::{
+        Lamport, LamportMessage, LamportPrivateKey, LamportPublicKey, LamportSignature, LamportType,
+    },
     musig2::{
         errors::Musig2SignerError,
         musig::{MuSig2Signer, MuSig2SignerApi},
@@ -29,7 +31,8 @@ use crate::{
     },
     rsa::{CryptoRng, OsRng, RSAKeyPair, Signature},
     winternitz::{
-        self, WinternitzPublicKey, WinternitzSignature, WinternitzType, checksum_length, to_checksummed_message
+        self, checksum_length, to_checksummed_message, WinternitzPublicKey, WinternitzSignature,
+        WinternitzType,
     },
 };
 
@@ -7049,7 +7052,8 @@ mod tests {
                     LamportType::SHA256,
                 )?;
 
-                let signature = key_manager.sign_lamport_message_by_pubkey(bit_value, &public_key)?;
+                let signature =
+                    key_manager.sign_lamport_message_by_pubkey(bit_value, &public_key)?;
 
                 assert_eq!(
                     signature.message_bit_length(),
@@ -7953,8 +7957,7 @@ mod tests {
         //
         // The byte-based method, (using message_bytes)  is ONLY for:
         // - Message lengths that are exact multiples of 8 bits (e.g., 8, 16, 24, 32, 256 bits)
-        let result =
-            key_manager2.sign_lamport_message_by_pubkey(&message_bytes, &public_key2);
+        let result = key_manager2.sign_lamport_message_by_pubkey(&message_bytes, &public_key2);
 
         // Assert that we get the expected MessageLengthMismatch error
         assert!(

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -724,8 +724,9 @@ impl KeyManager {
             let tx_id = self.begin_transaction();
 
             let index = self.next_keypair_index(key_type)?;
+            let next_index_to_store = index.checked_add(1).ok_or(KeyManagerError::IndexOverflow)?;
             self.keystore
-                .store_next_keypair_index(key_type, index + 1, tx_id)?;
+                .store_next_keypair_index(key_type, next_index_to_store, tx_id)?;
 
             self.commit_transaction(tx_id)?;
 
@@ -757,8 +758,9 @@ impl KeyManager {
             let tx_id = self.begin_transaction();
 
             let index = self.next_keypair_index(key_type)?;
+            let next_index_to_store = index.checked_add(1).ok_or(KeyManagerError::IndexOverflow)?;
             self.keystore
-                .store_next_keypair_index(key_type, index + 1, tx_id)?;
+                .store_next_keypair_index(key_type, next_index_to_store, tx_id)?;
 
             self.commit_transaction(tx_id)?;
 
@@ -889,8 +891,9 @@ impl KeyManager {
             let tx_id = self.begin_transaction();
 
             let index = self.next_winternitz_index()?;
+            let next_index_to_store = index.checked_add(1).ok_or(KeyManagerError::IndexOverflow)?;
             self.keystore
-                .store_next_winternitz_index(index + 1, tx_id)?;
+                .store_next_winternitz_index(next_index_to_store, tx_id)?;
 
             self.commit_transaction(tx_id)?;
 
@@ -1027,7 +1030,9 @@ impl KeyManager {
             let tx_id = self.begin_transaction();
 
             let index = self.next_lamport_index()?;
-            self.keystore.store_next_lamport_index(index + 1, tx_id)?;
+            let next_index_to_store = index.checked_add(1).ok_or(KeyManagerError::IndexOverflow)?;
+            self.keystore
+                .store_next_lamport_index(next_index_to_store, tx_id)?;
 
             self.commit_transaction(tx_id)?;
 

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -1726,10 +1726,6 @@ impl KeyManager {
         Ok(signature)
     }
 
-    // TODO write examples
-    // TODO mark imported used (similar to Winternitz)
-    // TODO check lamport extra data
-
     /// Exports the private key for a given public key.
     ///
     /// Note: Each public key uniquely maps to exactly one private key in the keystore.

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -7299,7 +7299,10 @@ mod tests {
             // Derive keys for single-bit signing
             let public_keys = key_manager.next_multiple_lamport(1, LamportType::SHA256, 2)?;
 
-            assert!(public_keys[0].derivation_index().unwrap() + 1 == public_keys[1].derivation_index().unwrap());
+            assert!(
+                public_keys[0].derivation_index().unwrap() + 1
+                    == public_keys[1].derivation_index().unwrap()
+            );
 
             // Sign bit 0 using index 0
             let signature_0 =

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -6961,8 +6961,16 @@ mod tests {
                     .sign_lamport_message_by_pubkey(&message_bits, &imported_public_key)?;
 
                 // Verify the signature
-                let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), &signature, &imported_public_key)?;
-                assert!(is_valid, "Signature verification should succeed for {:?}", hash_type);
+                let (is_valid, reconstructed_bits) = lamport.verify_signature(
+                    Some(&message_bits),
+                    &signature,
+                    &imported_public_key,
+                )?;
+                assert!(
+                    is_valid,
+                    "Signature verification should succeed for {:?}",
+                    hash_type
+                );
                 assert_eq!(reconstructed_bits.unwrap(), message_bits);
 
                 // Verify signature properties
@@ -7015,9 +7023,13 @@ mod tests {
                 key_manager.sign_lamport_message_by_pubkey(&message_bytes, &public_key)?;
 
             // Verify the signature
-            let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bytes), &signature, &public_key)?;
+            let (is_valid, reconstructed_bits) =
+                lamport.verify_signature(Some(&message_bytes), &signature, &public_key)?;
             assert!(is_valid, "Byte signature verification should succeed");
-            assert_eq!(reconstructed_bits.unwrap(), crate::lamport::bytes_to_bits(&message_bytes, 0));
+            assert_eq!(
+                reconstructed_bits.unwrap(),
+                crate::lamport::bytes_to_bits(&message_bytes, 0)
+            );
 
             Ok(())
         })
@@ -7059,8 +7071,13 @@ mod tests {
                 );
 
                 // Verify the signature
-                let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(bit_value), &signature, &public_key)?;
-                assert!(is_valid, "Single bit signature verification should succeed for bit={}", bit_value);
+                let (is_valid, reconstructed_bits) =
+                    lamport.verify_signature(Some(bit_value), &signature, &public_key)?;
+                assert!(
+                    is_valid,
+                    "Single bit signature verification should succeed for bit={}",
+                    bit_value
+                );
                 assert_eq!(reconstructed_bits.unwrap(), vec![bit_value]);
             }
 
@@ -7147,8 +7164,12 @@ mod tests {
                 let signature =
                     key_manager.sign_lamport_message_by_pubkey(&message_bits, public_key)?;
 
-                let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), &signature, public_key)?;
-                assert!(is_valid, "All stored keys should be retrievable and functional");
+                let (is_valid, reconstructed_bits) =
+                    lamport.verify_signature(Some(&message_bits), &signature, public_key)?;
+                assert!(
+                    is_valid,
+                    "All stored keys should be retrievable and functional"
+                );
                 assert_eq!(reconstructed_bits.unwrap(), message_bits);
             }
 
@@ -7175,7 +7196,8 @@ mod tests {
             let signature =
                 key_manager.sign_lamport_message_by_pubkey(&message_bits, &public_key)?;
 
-            let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), &signature, &public_key)?;
+            let (is_valid, reconstructed_bits) =
+                lamport.verify_signature(Some(&message_bits), &signature, &public_key)?;
             assert!(is_valid);
             assert_eq!(reconstructed_bits.unwrap(), message_bits);
 
@@ -7207,7 +7229,8 @@ mod tests {
                 let signature =
                     key_manager.sign_lamport_message_by_pubkey(&message_bits, public_key)?;
 
-                let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), &signature, public_key)?;
+                let (is_valid, reconstructed_bits) =
+                    lamport.verify_signature(Some(&message_bits), &signature, public_key)?;
                 assert!(is_valid, "Key {} should sign and verify correctly", i);
                 assert_eq!(reconstructed_bits.unwrap(), message_bits);
             }
@@ -7230,7 +7253,8 @@ mod tests {
                 key_manager.sign_lamport_message_by_index(&message_bits, LamportType::SHA256, 1)?;
 
             // Verify signature
-            let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), &signature, &public_keys[1])?;
+            let (is_valid, reconstructed_bits) =
+                lamport.verify_signature(Some(&message_bits), &signature, &public_keys[1])?;
             assert!(is_valid);
             assert_eq!(reconstructed_bits.unwrap(), message_bits);
 
@@ -7255,9 +7279,13 @@ mod tests {
             )?;
 
             // Verify signature
-            let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bytes), &signature, &public_keys[0])?;
+            let (is_valid, reconstructed_bits) =
+                lamport.verify_signature(Some(&message_bytes), &signature, &public_keys[0])?;
             assert!(is_valid);
-            assert_eq!(reconstructed_bits.unwrap(), crate::lamport::bytes_to_bits(&message_bytes, 0));
+            assert_eq!(
+                reconstructed_bits.unwrap(),
+                crate::lamport::bytes_to_bits(&message_bytes, 0)
+            );
 
             Ok(())
         })
@@ -7274,14 +7302,16 @@ mod tests {
             // Sign bit 0 using index 0
             let signature_0 =
                 key_manager.sign_lamport_message_by_index(false, LamportType::SHA256, 0)?;
-            let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(false), &signature_0, &public_keys[0])?;
+            let (is_valid, reconstructed_bits) =
+                lamport.verify_signature(Some(false), &signature_0, &public_keys[0])?;
             assert!(is_valid);
             assert_eq!(reconstructed_bits.unwrap(), vec![false]);
 
             // Sign bit 1 using index 1
             let signature_1 =
                 key_manager.sign_lamport_message_by_index(true, LamportType::SHA256, 1)?;
-            let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(true), &signature_1, &public_keys[1])?;
+            let (is_valid, reconstructed_bits) =
+                lamport.verify_signature(Some(true), &signature_1, &public_keys[1])?;
             assert!(is_valid);
             assert_eq!(reconstructed_bits.unwrap(), vec![true]);
 
@@ -7312,7 +7342,8 @@ mod tests {
                 let signature =
                     key_manager.sign_lamport_message_by_pubkey(&message_bits, &public_key)?;
 
-                let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), &signature, &public_key)?;
+                let (is_valid, reconstructed_bits) =
+                    lamport.verify_signature(Some(&message_bits), &signature, &public_key)?;
                 assert!(is_valid, "Hash type {:?} should work correctly", hash_type);
                 assert_eq!(reconstructed_bits.unwrap(), message_bits);
             }
@@ -7475,7 +7506,8 @@ mod tests {
                 let signature =
                     key_manager.sign_lamport_message_by_pubkey(&message_bits, &public_key)?;
 
-                let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), &signature, &public_key)?;
+                let (is_valid, reconstructed_bits) =
+                    lamport.verify_signature(Some(&message_bits), &signature, &public_key)?;
                 assert!(is_valid, "Bit length {} should work correctly", bit_length);
                 assert_eq!(reconstructed_bits.unwrap(), message_bits);
             }
@@ -7526,17 +7558,20 @@ mod tests {
             let message_bits = vec![true; 256];
 
             let sig1 = key_manager.sign_lamport_message_by_pubkey(&message_bits, &derived_key)?;
-            let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), &sig1, &derived_key)?;
+            let (is_valid, reconstructed_bits) =
+                lamport.verify_signature(Some(&message_bits), &sig1, &derived_key)?;
             assert!(is_valid);
             assert_eq!(reconstructed_bits.unwrap(), message_bits);
 
             let sig2 = key_manager.sign_lamport_message_by_pubkey(&message_bits, &imported_key)?;
-            let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), &sig2, &imported_key)?;
+            let (is_valid, reconstructed_bits) =
+                lamport.verify_signature(Some(&message_bits), &sig2, &imported_key)?;
             assert!(is_valid);
             assert_eq!(reconstructed_bits.unwrap(), message_bits);
 
             let sig3 = key_manager.sign_lamport_message_by_pubkey(&message_bits, &derived_key2)?;
-            let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), &sig3, &derived_key2)?;
+            let (is_valid, reconstructed_bits) =
+                lamport.verify_signature(Some(&message_bits), &sig3, &derived_key2)?;
             assert!(is_valid);
             assert_eq!(reconstructed_bits.unwrap(), message_bits);
 
@@ -7625,7 +7660,8 @@ mod tests {
 
             // All signatures should verify with their respective keys
             for (i, sig) in signatures.iter().enumerate() {
-                let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), sig, &keys[i])?;
+                let (is_valid, reconstructed_bits) =
+                    lamport.verify_signature(Some(&message_bits), sig, &keys[i])?;
                 assert!(is_valid, "Signature {} should verify", i);
                 assert_eq!(reconstructed_bits.unwrap(), message_bits);
             }
@@ -7653,9 +7689,13 @@ mod tests {
                     idx as u32,
                 )?;
 
-                let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bytes), &signature, &public_key)?;
+                let (is_valid, reconstructed_bits) =
+                    lamport.verify_signature(Some(&message_bytes), &signature, &public_key)?;
                 assert!(is_valid, "Byte size {} should work correctly", byte_size);
-                assert_eq!(reconstructed_bits.unwrap(), crate::lamport::bytes_to_bits(&message_bytes, 0));
+                assert_eq!(
+                    reconstructed_bits.unwrap(),
+                    crate::lamport::bytes_to_bits(&message_bytes, 0)
+                );
             }
 
             Ok(())
@@ -7694,7 +7734,7 @@ mod tests {
                 let (is_valid, reconstructed_bits) = lamport.verify_signature(
                     Some(wire_values[i as usize]),
                     &signatures[i as usize],
-                    &wire_keys[i as usize]
+                    &wire_keys[i as usize],
                 )?;
                 assert!(is_valid, "Wire {} signature should verify", i);
                 assert_eq!(reconstructed_bits.unwrap(), vec![wire_values[i as usize]]);
@@ -7703,7 +7743,7 @@ mod tests {
                 let (is_valid, _) = lamport.verify_signature(
                     Some(!wire_values[i as usize]),
                     &signatures[i as usize],
-                    &wire_keys[i as usize]
+                    &wire_keys[i as usize],
                 )?;
                 assert!(!is_valid, "Wire {} should fail with wrong bit value", i);
             }
@@ -7732,7 +7772,8 @@ mod tests {
 
             let sig1 =
                 key_manager.sign_lamport_message_by_index(&message_bits, LamportType::SHA256, 0)?;
-            let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), &sig1, &key_sha256)?;
+            let (is_valid, reconstructed_bits) =
+                lamport.verify_signature(Some(&message_bits), &sig1, &key_sha256)?;
             assert!(is_valid);
             assert_eq!(reconstructed_bits.unwrap(), message_bits);
 
@@ -7741,7 +7782,8 @@ mod tests {
                 LamportType::RIPEMD160,
                 1,
             )?;
-            let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), &sig2, &key_ripemd160)?;
+            let (is_valid, reconstructed_bits) =
+                lamport.verify_signature(Some(&message_bits), &sig2, &key_ripemd160)?;
             assert!(is_valid);
             assert_eq!(reconstructed_bits.unwrap(), message_bits);
 
@@ -7750,7 +7792,8 @@ mod tests {
                 LamportType::HASH160,
                 2,
             )?;
-            let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), &sig3, &key_hash160)?;
+            let (is_valid, reconstructed_bits) =
+                lamport.verify_signature(Some(&message_bits), &sig3, &key_hash160)?;
             assert!(is_valid);
             assert_eq!(reconstructed_bits.unwrap(), message_bits);
 
@@ -7870,7 +7913,11 @@ mod tests {
                     idx,
                 )?;
 
-                let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), &signature, &keys[idx as usize])?;
+                let (is_valid, reconstructed_bits) = lamport.verify_signature(
+                    Some(&message_bits),
+                    &signature,
+                    &keys[idx as usize],
+                )?;
                 assert!(is_valid, "Key at index {} should work correctly", idx);
                 assert_eq!(reconstructed_bits.unwrap(), message_bits);
             }
@@ -7922,7 +7969,8 @@ mod tests {
         let signature1 = key_manager1.sign_lamport_message_by_pubkey(&message_bits, &public_key)?;
 
         // Verify the first signature
-        let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), &signature1, &public_key)?;
+        let (is_valid, reconstructed_bits) =
+            lamport.verify_signature(Some(&message_bits), &signature1, &public_key)?;
         assert!(is_valid, "Signature should verify with bit-based method");
         assert_eq!(reconstructed_bits.unwrap(), message_bits);
 

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -18,13 +18,20 @@ use uuid::Uuid;
 use zeroize::Zeroizing;
 
 use crate::{
-    errors::KeyManagerError, key_store::KeyStore, key_type::BitcoinKeyType, lamport::{Lamport, LamportPrivateKey, LamportPublicKey, LamportSignature}, musig2::{
+    errors::KeyManagerError,
+    key_store::KeyStore,
+    key_type::BitcoinKeyType,
+    lamport::{Lamport, LamportPrivateKey, LamportPublicKey, LamportSignature},
+    musig2::{
         errors::Musig2SignerError,
         musig::{MuSig2Signer, MuSig2SignerApi},
         types::MessageId,
-    }, rsa::{CryptoRng, OsRng, RSAKeyPair, Signature}, winternitz::{
-        self, WinternitzPublicKey, WinternitzSignature, WinternitzType, checksum_length, to_checksummed_message
-    }
+    },
+    rsa::{CryptoRng, OsRng, RSAKeyPair, Signature},
+    winternitz::{
+        self, checksum_length, to_checksummed_message, WinternitzPublicKey, WinternitzSignature,
+        WinternitzType,
+    },
 };
 
 use musig2::{sign_partial, AggNonce, PartialSignature, PubNonce, SecNonce};
@@ -316,8 +323,9 @@ impl KeyManager {
 
     pub fn import_lamport_private_key(
         &self,
-        private_key: &LamportPrivateKey
-    ) -> Result<LamportPublicKey, KeyManagerError> { // Returns the corresponding public key
+        private_key: &LamportPrivateKey,
+    ) -> Result<LamportPublicKey, KeyManagerError> {
+        // Returns the corresponding public key
 
         let public_key = private_key.public_key()?;
         self.keystore.store_lamport_key(private_key, &public_key)?;
@@ -1231,10 +1239,10 @@ impl KeyManager {
     pub fn sign_lamport_message_by_pubkey(
         &self,
         message_bits: &[bool],
-        public_key: &LamportPublicKey
+        public_key: &LamportPublicKey,
     ) -> Result<LamportSignature, KeyManagerError> {
-
-        let private_key = self.keystore
+        let private_key = self
+            .keystore
             .load_lamport_key(public_key)?
             .ok_or(KeyManagerError::LamportKeyNotFound)?;
 
@@ -1261,9 +1269,10 @@ impl KeyManager {
     pub fn sign_lamport_message_bytes_by_pubkey(
         &self,
         message_bytes: &[u8],
-        public_key: &LamportPublicKey
+        public_key: &LamportPublicKey,
     ) -> Result<LamportSignature, KeyManagerError> {
-        let private_key = self.keystore
+        let private_key = self
+            .keystore
             .load_lamport_key(public_key)?
             .ok_or(KeyManagerError::LamportKeyNotFound)?;
 
@@ -1289,10 +1298,10 @@ impl KeyManager {
     pub fn sign_lamport_bit_by_pubkey(
         &self,
         message_bit: bool, // bool representing a bit false = 0, true = 1
-        public_key: &LamportPublicKey
+        public_key: &LamportPublicKey,
     ) -> Result<LamportSignature, KeyManagerError> {
-
-        let private_key = self.keystore
+        let private_key = self
+            .keystore
             .load_lamport_key(public_key)?
             .ok_or(KeyManagerError::LamportKeyNotFound)?;
 

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -6961,11 +6961,9 @@ mod tests {
                     .sign_lamport_message_by_pubkey(&message_bits, &imported_public_key)?;
 
                 // Verify the signature
-                assert!(
-                    lamport.verify_signature(&message_bits, &signature, &imported_public_key)?,
-                    "Signature verification should succeed for {:?}",
-                    hash_type
-                );
+                let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), &signature, &imported_public_key)?;
+                assert!(is_valid, "Signature verification should succeed for {:?}", hash_type);
+                assert_eq!(reconstructed_bits.unwrap(), message_bits);
 
                 // Verify signature properties
                 assert_eq!(
@@ -7017,10 +7015,9 @@ mod tests {
                 key_manager.sign_lamport_message_by_pubkey(&message_bytes, &public_key)?;
 
             // Verify the signature
-            assert!(
-                lamport.verify_signature(&message_bytes, &signature, &public_key)?,
-                "Byte signature verification should succeed"
-            );
+            let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bytes), &signature, &public_key)?;
+            assert!(is_valid, "Byte signature verification should succeed");
+            assert_eq!(reconstructed_bits.unwrap(), crate::lamport::bytes_to_bits(&message_bytes, 0));
 
             Ok(())
         })
@@ -7062,11 +7059,9 @@ mod tests {
                 );
 
                 // Verify the signature
-                assert!(
-                    lamport.verify_signature(bit_value, &signature, &public_key)?,
-                    "Single bit signature verification should succeed for bit={}",
-                    bit_value
-                );
+                let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(bit_value), &signature, &public_key)?;
+                assert!(is_valid, "Single bit signature verification should succeed for bit={}", bit_value);
+                assert_eq!(reconstructed_bits.unwrap(), vec![bit_value]);
             }
 
             Ok(())
@@ -7152,10 +7147,9 @@ mod tests {
                 let signature =
                     key_manager.sign_lamport_message_by_pubkey(&message_bits, public_key)?;
 
-                assert!(
-                    lamport.verify_signature(&message_bits, &signature, public_key)?,
-                    "All stored keys should be retrievable and functional"
-                );
+                let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), &signature, public_key)?;
+                assert!(is_valid, "All stored keys should be retrievable and functional");
+                assert_eq!(reconstructed_bits.unwrap(), message_bits);
             }
 
             Ok(())
@@ -7181,7 +7175,9 @@ mod tests {
             let signature =
                 key_manager.sign_lamport_message_by_pubkey(&message_bits, &public_key)?;
 
-            assert!(lamport.verify_signature(&message_bits, &signature, &public_key)?);
+            let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), &signature, &public_key)?;
+            assert!(is_valid);
+            assert_eq!(reconstructed_bits.unwrap(), message_bits);
 
             Ok(())
         })
@@ -7211,11 +7207,9 @@ mod tests {
                 let signature =
                     key_manager.sign_lamport_message_by_pubkey(&message_bits, public_key)?;
 
-                assert!(
-                    lamport.verify_signature(&message_bits, &signature, public_key)?,
-                    "Key {} should sign and verify correctly",
-                    i
-                );
+                let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), &signature, public_key)?;
+                assert!(is_valid, "Key {} should sign and verify correctly", i);
+                assert_eq!(reconstructed_bits.unwrap(), message_bits);
             }
 
             Ok(())
@@ -7236,7 +7230,9 @@ mod tests {
                 key_manager.sign_lamport_message_by_index(&message_bits, LamportType::SHA256, 1)?;
 
             // Verify signature
-            assert!(lamport.verify_signature(&message_bits, &signature, &public_keys[1])?);
+            let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), &signature, &public_keys[1])?;
+            assert!(is_valid);
+            assert_eq!(reconstructed_bits.unwrap(), message_bits);
 
             Ok(())
         })
@@ -7259,7 +7255,9 @@ mod tests {
             )?;
 
             // Verify signature
-            assert!(lamport.verify_signature(&message_bytes, &signature, &public_keys[0])?);
+            let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bytes), &signature, &public_keys[0])?;
+            assert!(is_valid);
+            assert_eq!(reconstructed_bits.unwrap(), crate::lamport::bytes_to_bits(&message_bytes, 0));
 
             Ok(())
         })
@@ -7276,12 +7274,16 @@ mod tests {
             // Sign bit 0 using index 0
             let signature_0 =
                 key_manager.sign_lamport_message_by_index(false, LamportType::SHA256, 0)?;
-            assert!(lamport.verify_signature(false, &signature_0, &public_keys[0])?);
+            let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(false), &signature_0, &public_keys[0])?;
+            assert!(is_valid);
+            assert_eq!(reconstructed_bits.unwrap(), vec![false]);
 
             // Sign bit 1 using index 1
             let signature_1 =
                 key_manager.sign_lamport_message_by_index(true, LamportType::SHA256, 1)?;
-            assert!(lamport.verify_signature(true, &signature_1, &public_keys[1])?);
+            let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(true), &signature_1, &public_keys[1])?;
+            assert!(is_valid);
+            assert_eq!(reconstructed_bits.unwrap(), vec![true]);
 
             Ok(())
         })
@@ -7310,11 +7312,9 @@ mod tests {
                 let signature =
                     key_manager.sign_lamport_message_by_pubkey(&message_bits, &public_key)?;
 
-                assert!(
-                    lamport.verify_signature(&message_bits, &signature, &public_key)?,
-                    "Hash type {:?} should work correctly",
-                    hash_type
-                );
+                let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), &signature, &public_key)?;
+                assert!(is_valid, "Hash type {:?} should work correctly", hash_type);
+                assert_eq!(reconstructed_bits.unwrap(), message_bits);
             }
 
             Ok(())
@@ -7475,11 +7475,9 @@ mod tests {
                 let signature =
                     key_manager.sign_lamport_message_by_pubkey(&message_bits, &public_key)?;
 
-                assert!(
-                    lamport.verify_signature(&message_bits, &signature, &public_key)?,
-                    "Bit length {} should work correctly",
-                    bit_length
-                );
+                let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), &signature, &public_key)?;
+                assert!(is_valid, "Bit length {} should work correctly", bit_length);
+                assert_eq!(reconstructed_bits.unwrap(), message_bits);
             }
 
             Ok(())
@@ -7528,13 +7526,19 @@ mod tests {
             let message_bits = vec![true; 256];
 
             let sig1 = key_manager.sign_lamport_message_by_pubkey(&message_bits, &derived_key)?;
-            assert!(lamport.verify_signature(&message_bits, &sig1, &derived_key)?);
+            let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), &sig1, &derived_key)?;
+            assert!(is_valid);
+            assert_eq!(reconstructed_bits.unwrap(), message_bits);
 
             let sig2 = key_manager.sign_lamport_message_by_pubkey(&message_bits, &imported_key)?;
-            assert!(lamport.verify_signature(&message_bits, &sig2, &imported_key)?);
+            let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), &sig2, &imported_key)?;
+            assert!(is_valid);
+            assert_eq!(reconstructed_bits.unwrap(), message_bits);
 
             let sig3 = key_manager.sign_lamport_message_by_pubkey(&message_bits, &derived_key2)?;
-            assert!(lamport.verify_signature(&message_bits, &sig3, &derived_key2)?);
+            let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), &sig3, &derived_key2)?;
+            assert!(is_valid);
+            assert_eq!(reconstructed_bits.unwrap(), message_bits);
 
             Ok(())
         })
@@ -7621,11 +7625,9 @@ mod tests {
 
             // All signatures should verify with their respective keys
             for (i, sig) in signatures.iter().enumerate() {
-                assert!(
-                    lamport.verify_signature(&message_bits, sig, &keys[i])?,
-                    "Signature {} should verify",
-                    i
-                );
+                let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), sig, &keys[i])?;
+                assert!(is_valid, "Signature {} should verify", i);
+                assert_eq!(reconstructed_bits.unwrap(), message_bits);
             }
 
             Ok(())
@@ -7651,11 +7653,9 @@ mod tests {
                     idx as u32,
                 )?;
 
-                assert!(
-                    lamport.verify_signature(&message_bytes, &signature, &public_key)?,
-                    "Byte size {} should work correctly",
-                    byte_size
-                );
+                let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bytes), &signature, &public_key)?;
+                assert!(is_valid, "Byte size {} should work correctly", byte_size);
+                assert_eq!(reconstructed_bits.unwrap(), crate::lamport::bytes_to_bits(&message_bytes, 0));
             }
 
             Ok(())
@@ -7691,26 +7691,21 @@ mod tests {
 
             // Verify all wire signatures
             for i in 0..wire_count {
-                assert!(
-                    lamport.verify_signature(
-                        wire_values[i as usize],
-                        &signatures[i as usize],
-                        &wire_keys[i as usize]
-                    )?,
-                    "Wire {} signature should verify",
-                    i
-                );
+                let (is_valid, reconstructed_bits) = lamport.verify_signature(
+                    Some(wire_values[i as usize]),
+                    &signatures[i as usize],
+                    &wire_keys[i as usize]
+                )?;
+                assert!(is_valid, "Wire {} signature should verify", i);
+                assert_eq!(reconstructed_bits.unwrap(), vec![wire_values[i as usize]]);
 
                 // Verify that wrong bit value fails
-                assert!(
-                    !lamport.verify_signature(
-                        !wire_values[i as usize],
-                        &signatures[i as usize],
-                        &wire_keys[i as usize]
-                    )?,
-                    "Wire {} should fail with wrong bit value",
-                    i
-                );
+                let (is_valid, _) = lamport.verify_signature(
+                    Some(!wire_values[i as usize]),
+                    &signatures[i as usize],
+                    &wire_keys[i as usize]
+                )?;
+                assert!(!is_valid, "Wire {} should fail with wrong bit value", i);
             }
 
             Ok(())
@@ -7737,21 +7732,27 @@ mod tests {
 
             let sig1 =
                 key_manager.sign_lamport_message_by_index(&message_bits, LamportType::SHA256, 0)?;
-            assert!(lamport.verify_signature(&message_bits, &sig1, &key_sha256)?);
+            let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), &sig1, &key_sha256)?;
+            assert!(is_valid);
+            assert_eq!(reconstructed_bits.unwrap(), message_bits);
 
             let sig2 = key_manager.sign_lamport_message_by_index(
                 &message_bits,
                 LamportType::RIPEMD160,
                 1,
             )?;
-            assert!(lamport.verify_signature(&message_bits, &sig2, &key_ripemd160)?);
+            let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), &sig2, &key_ripemd160)?;
+            assert!(is_valid);
+            assert_eq!(reconstructed_bits.unwrap(), message_bits);
 
             let sig3 = key_manager.sign_lamport_message_by_index(
                 &message_bits,
                 LamportType::HASH160,
                 2,
             )?;
-            assert!(lamport.verify_signature(&message_bits, &sig3, &key_hash160)?);
+            let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), &sig3, &key_hash160)?;
+            assert!(is_valid);
+            assert_eq!(reconstructed_bits.unwrap(), message_bits);
 
             Ok(())
         })
@@ -7869,11 +7870,9 @@ mod tests {
                     idx,
                 )?;
 
-                assert!(
-                    lamport.verify_signature(&message_bits, &signature, &keys[idx as usize])?,
-                    "Key at index {} should work correctly",
-                    idx
-                );
+                let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), &signature, &keys[idx as usize])?;
+                assert!(is_valid, "Key at index {} should work correctly", idx);
+                assert_eq!(reconstructed_bits.unwrap(), message_bits);
             }
 
             Ok(())
@@ -7923,10 +7922,9 @@ mod tests {
         let signature1 = key_manager1.sign_lamport_message_by_pubkey(&message_bits, &public_key)?;
 
         // Verify the first signature
-        assert!(
-            lamport.verify_signature(&message_bits, &signature1, &public_key)?,
-            "Signature should verify with bit-based method"
-        );
+        let (is_valid, reconstructed_bits) = lamport.verify_signature(Some(&message_bits), &signature1, &public_key)?;
+        assert!(is_valid, "Signature should verify with bit-based method");
+        assert_eq!(reconstructed_bits.unwrap(), message_bits);
 
         // Clean up first key manager
         drop(key_manager1);

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -372,7 +372,8 @@ impl KeyManager {
         let public_key = private_key.public_key()?;
 
         // store the lamport keys in a way that we can retrieve them for signing
-        self.keystore.store_lamport_imported_key(&private_key, &public_key)?;
+        self.keystore
+            .store_lamport_imported_key(&private_key, &public_key)?;
 
         Ok(public_key)
     }
@@ -996,12 +997,8 @@ impl KeyManager {
         let master_secret = self.keystore.load_lamport_seed()?;
 
         let lamport = crate::lamport::Lamport::new();
-        let public_key = lamport.generate_public_key(
-            &*master_secret,
-            key_type,
-            message_bit_length,
-            index,
-        )?;
+        let public_key =
+            lamport.generate_public_key(&*master_secret, key_type, message_bit_length, index)?;
 
         Ok(public_key)
     }
@@ -1447,20 +1444,14 @@ impl KeyManager {
         message_bits: &[bool],
         public_key: &LamportPublicKey,
     ) -> Result<LamportSignature, KeyManagerError> {
-
-        if public_key.imported(){
+        if public_key.imported() {
             self.sign_lamport_message_by_pubkey_imported(message_bits, public_key)
-        }
-        else {
-            let index = public_key.derivation_index()
+        } else {
+            let index = public_key
+                .derivation_index()
                 .ok_or(KeyManagerError::LamportKeyDerivationIndexNotFound)?;
-            self.sign_lamport_message_by_index(
-                message_bits,
-                public_key.hash_type(),
-                index,
-            )
+            self.sign_lamport_message_by_index(message_bits, public_key.hash_type(), index)
         }
-
     }
 
     // private
@@ -1469,30 +1460,30 @@ impl KeyManager {
         message_bits: &[bool],
         public_key: &LamportPublicKey,
     ) -> Result<LamportSignature, KeyManagerError> {
-            let private_key = self
-                .keystore
-                .load_lamport_imported_key(public_key)?
-                .ok_or(KeyManagerError::LamportKeyNotFound)?;
+        let private_key = self
+            .keystore
+            .load_lamport_imported_key(public_key)?
+            .ok_or(KeyManagerError::LamportKeyNotFound)?;
 
-            let tx_id = self.begin_transaction();
-            // check if index was already used, if its error, if not mark and save
-            #[cfg(feature = "lamport_idx_check")]
-            match self
-                .keystore
-                .check_and_mark_lamport_used_imported(public_key, tx_id)
-            {
-                Ok(()) => {}
-                Err(e) => {
-                    self.rollback_transaction(tx_id)?;
-                    return Err(e);
-                }
+        let tx_id = self.begin_transaction();
+        // check if index was already used, if its error, if not mark and save
+        #[cfg(feature = "lamport_idx_check")]
+        match self
+            .keystore
+            .check_and_mark_lamport_used_imported(public_key, tx_id)
+        {
+            Ok(()) => {}
+            Err(e) => {
+                self.rollback_transaction(tx_id)?;
+                return Err(e);
             }
+        }
 
-            let lamport = Lamport::new();
-            let sig = lamport.sign_message(message_bits, &private_key)?;
+        let lamport = Lamport::new();
+        let sig = lamport.sign_message(message_bits, &private_key)?;
 
-            self.commit_transaction(tx_id)?;
-            Ok(sig)
+        self.commit_transaction(tx_id)?;
+        Ok(sig)
     }
 
     // For one-time lamport keys
@@ -1505,12 +1496,8 @@ impl KeyManager {
     ) -> Result<LamportSignature, KeyManagerError> {
         let master_secret = self.keystore.load_lamport_seed()?;
         let lamport = Lamport::new();
-        let private_key = lamport.generate_private_key(
-            &*master_secret,
-            key_type,
-            message_bits.len(),
-            index,
-        )?;
+        let private_key =
+            lamport.generate_private_key(&*master_secret, key_type, message_bits.len(), index)?;
 
         let tx_id = self.begin_transaction();
 
@@ -1553,17 +1540,13 @@ impl KeyManager {
         message_bytes: &[u8],
         public_key: &LamportPublicKey,
     ) -> Result<LamportSignature, KeyManagerError> {
-        if public_key.imported(){
+        if public_key.imported() {
             self.sign_lamport_message_bytes_by_pubkey_imported(message_bytes, public_key)
-        }
-        else {
-            let index = public_key.derivation_index()
+        } else {
+            let index = public_key
+                .derivation_index()
                 .ok_or(KeyManagerError::LamportKeyDerivationIndexNotFound)?;
-            self.sign_lamport_message_bytes_by_index(
-                message_bytes,
-                public_key.hash_type(),
-                index,
-            )
+            self.sign_lamport_message_bytes_by_index(message_bytes, public_key.hash_type(), index)
         }
     }
 
@@ -1573,32 +1556,31 @@ impl KeyManager {
         message_bytes: &[u8],
         public_key: &LamportPublicKey,
     ) -> Result<LamportSignature, KeyManagerError> {
-            let private_key = self
-                .keystore
-                .load_lamport_imported_key(public_key)?
-                .ok_or(KeyManagerError::LamportKeyNotFound)?;
+        let private_key = self
+            .keystore
+            .load_lamport_imported_key(public_key)?
+            .ok_or(KeyManagerError::LamportKeyNotFound)?;
 
-            let tx_id = self.begin_transaction();
-            // check if index was already used, if its error, if not mark and save
-            #[cfg(feature = "lamport_idx_check")]
-            match self
-                .keystore
-                .check_and_mark_lamport_used_imported(public_key, tx_id)
-            {
-                Ok(()) => {}
-                Err(e) => {
-                    self.rollback_transaction(tx_id)?;
-                    return Err(e);
-                }
+        let tx_id = self.begin_transaction();
+        // check if index was already used, if its error, if not mark and save
+        #[cfg(feature = "lamport_idx_check")]
+        match self
+            .keystore
+            .check_and_mark_lamport_used_imported(public_key, tx_id)
+        {
+            Ok(()) => {}
+            Err(e) => {
+                self.rollback_transaction(tx_id)?;
+                return Err(e);
             }
+        }
 
-            let lamport = Lamport::new();
-            let sig = lamport.sign_message_bytes(message_bytes, &private_key)?;
+        let lamport = Lamport::new();
+        let sig = lamport.sign_message_bytes(message_bytes, &private_key)?;
 
-            self.commit_transaction(tx_id)?;
-            Ok(sig)
+        self.commit_transaction(tx_id)?;
+        Ok(sig)
     }
-
 
     // For one-time lamport keys
     // TODO: make this fun private to force sign by key? Protocol should store the key and not the index
@@ -1613,7 +1595,7 @@ impl KeyManager {
         let private_key = lamport.generate_private_key(
             &*master_secret,
             key_type,
-            message_bytes.len() * 8,  // Convert bytes to bits
+            message_bytes.len() * 8, // Convert bytes to bits
             index,
         )?;
 
@@ -1657,17 +1639,13 @@ impl KeyManager {
         message_bit: bool, // bool representing a bit false = 0, true = 1
         public_key: &LamportPublicKey,
     ) -> Result<LamportSignature, KeyManagerError> {
-        if public_key.imported(){
+        if public_key.imported() {
             self.sign_lamport_bit_by_pubkey_imported(message_bit, public_key)
-        }
-        else {
-            let index = public_key.derivation_index()
+        } else {
+            let index = public_key
+                .derivation_index()
                 .ok_or(KeyManagerError::LamportKeyDerivationIndexNotFound)?;
-            self.sign_lamport_bit_by_index(
-                message_bit,
-                public_key.hash_type(),
-                index,
-            )
+            self.sign_lamport_bit_by_index(message_bit, public_key.hash_type(), index)
         }
     }
 
@@ -1677,30 +1655,30 @@ impl KeyManager {
         message_bit: bool, // bool representing a bit false = 0, true = 1
         public_key: &LamportPublicKey,
     ) -> Result<LamportSignature, KeyManagerError> {
-            let private_key = self
-                .keystore
-                .load_lamport_imported_key(public_key)?
-                .ok_or(KeyManagerError::LamportKeyNotFound)?;
+        let private_key = self
+            .keystore
+            .load_lamport_imported_key(public_key)?
+            .ok_or(KeyManagerError::LamportKeyNotFound)?;
 
-            let tx_id = self.begin_transaction();
-            // check if index was already used, if its error, if not mark and save
-            #[cfg(feature = "lamport_idx_check")]
-            match self
-                .keystore
-                .check_and_mark_lamport_used_imported(public_key, tx_id)
-            {
-                Ok(()) => {}
-                Err(e) => {
-                    self.rollback_transaction(tx_id)?;
-                    return Err(e);
-                }
+        let tx_id = self.begin_transaction();
+        // check if index was already used, if its error, if not mark and save
+        #[cfg(feature = "lamport_idx_check")]
+        match self
+            .keystore
+            .check_and_mark_lamport_used_imported(public_key, tx_id)
+        {
+            Ok(()) => {}
+            Err(e) => {
+                self.rollback_transaction(tx_id)?;
+                return Err(e);
             }
+        }
 
-            let lamport = Lamport::new();
-            let sig = lamport.sign_message_bit(message_bit, &private_key)?;
+        let lamport = Lamport::new();
+        let sig = lamport.sign_message_bit(message_bit, &private_key)?;
 
-            self.commit_transaction(tx_id)?;
-            Ok(sig)
+        self.commit_transaction(tx_id)?;
+        Ok(sig)
     }
 
     // For one-time lamport keys
@@ -1716,7 +1694,7 @@ impl KeyManager {
         let private_key = lamport.generate_private_key(
             &*master_secret,
             key_type,
-            1,  // Single bit
+            1, // Single bit
             index,
         )?;
 
@@ -7155,10 +7133,8 @@ mod tests {
                     .collect();
 
                 // Sign the message using the imported key
-                let signature = key_manager.sign_lamport_message_by_pubkey(
-                    &message_bits,
-                    &imported_public_key,
-                )?;
+                let signature = key_manager
+                    .sign_lamport_message_by_pubkey(&message_bits, &imported_public_key)?;
 
                 // Verify the signature
                 assert!(
@@ -7237,7 +7213,8 @@ mod tests {
             rng.fill_bytes(&mut master_secret);
 
             // Generate a key for a single bit
-            let private_key = lamport.generate_private_key(&master_secret, LamportType::SHA256, 1, 0)?;
+            let private_key =
+                lamport.generate_private_key(&master_secret, LamportType::SHA256, 1, 0)?;
 
             // Extract bytes from private key for import
             let (bytes_0s, bytes_1s) = private_key.to_bytes_splitted();
@@ -7251,8 +7228,7 @@ mod tests {
 
             // Test signing both bit values
             for bit_value in [false, true] {
-                let signature =
-                    key_manager.sign_lamport_bit_by_pubkey(bit_value, &public_key)?;
+                let signature = key_manager.sign_lamport_bit_by_pubkey(bit_value, &public_key)?;
 
                 assert_eq!(
                     signature.message_bit_length(),
@@ -7291,10 +7267,7 @@ mod tests {
             let message_bits = vec![true; 256];
             let result = key_manager.sign_lamport_message_by_pubkey(&message_bits, &public_key);
 
-            assert!(
-                result.is_err(),
-                "Should fail to sign with non-imported key"
-            );
+            assert!(result.is_err(), "Should fail to sign with non-imported key");
 
             if let Err(KeyManagerError::LamportKeyNotFound) = result {
                 // Expected error
@@ -7338,8 +7311,7 @@ mod tests {
 
             // Verify all keys can be retrieved and used for signing
             for (_original_private, public_key) in keys.iter() {
-                let message_bits: Vec<bool> =
-                    (0..256).map(|i| (i % 2) == 0).collect();
+                let message_bits: Vec<bool> = (0..256).map(|i| (i % 2) == 0).collect();
 
                 let signature =
                     key_manager.sign_lamport_message_by_pubkey(&message_bits, public_key)?;
@@ -7424,7 +7396,8 @@ mod tests {
 
             // Sign using index
             let message_bits = vec![true, false, true, false].repeat(32);
-            let signature = key_manager.sign_lamport_message_by_index(&message_bits, LamportType::SHA256, 1)?;
+            let signature =
+                key_manager.sign_lamport_message_by_index(&message_bits, LamportType::SHA256, 1)?;
 
             // Verify signature
             assert!(lamport.verify_signature(&message_bits, &signature, &public_keys[1])?);
@@ -7443,7 +7416,11 @@ mod tests {
 
             // Sign a 32-byte message using index
             let message_bytes = [0x42u8; 32];
-            let signature = key_manager.sign_lamport_message_bytes_by_index(&message_bytes, LamportType::SHA256, 0)?;
+            let signature = key_manager.sign_lamport_message_bytes_by_index(
+                &message_bytes,
+                LamportType::SHA256,
+                0,
+            )?;
 
             // Verify signature
             assert!(lamport.verify_signature_bytes(&message_bytes, &signature, &public_keys[0])?);
@@ -7461,11 +7438,13 @@ mod tests {
             let public_keys = key_manager.next_multiple_lamport(1, LamportType::SHA256, 2)?;
 
             // Sign bit 0 using index 0
-            let signature_0 = key_manager.sign_lamport_bit_by_index(false, LamportType::SHA256, 0)?;
+            let signature_0 =
+                key_manager.sign_lamport_bit_by_index(false, LamportType::SHA256, 0)?;
             assert!(lamport.verify_signature_bit(false, &signature_0, &public_keys[0])?);
 
             // Sign bit 1 using index 1
-            let signature_1 = key_manager.sign_lamport_bit_by_index(true, LamportType::SHA256, 1)?;
+            let signature_1 =
+                key_manager.sign_lamport_bit_by_index(true, LamportType::SHA256, 1)?;
             assert!(lamport.verify_signature_bit(true, &signature_1, &public_keys[1])?);
 
             Ok(())
@@ -7545,7 +7524,10 @@ mod tests {
             if let Err(KeyManagerError::LamportImportedKeyAlreadyUsed) = result {
                 // Expected error
             } else {
-                panic!("Expected LamportImportedKeyAlreadyUsed error, got {:?}", result);
+                panic!(
+                    "Expected LamportImportedKeyAlreadyUsed error, got {:?}",
+                    result
+                );
             }
 
             Ok(())
@@ -7562,10 +7544,12 @@ mod tests {
 
             // Sign once - should succeed
             let message_bits = vec![false; 256];
-            let _signature = key_manager.sign_lamport_message_by_index(&message_bits, LamportType::SHA256, 0)?;
+            let _signature =
+                key_manager.sign_lamport_message_by_index(&message_bits, LamportType::SHA256, 0)?;
 
             // Try to sign again with the same key - should fail
-            let result = key_manager.sign_lamport_message_by_index(&message_bits, LamportType::SHA256, 0);
+            let result =
+                key_manager.sign_lamport_message_by_index(&message_bits, LamportType::SHA256, 0);
 
             assert!(
                 result.is_err(),
@@ -7717,12 +7701,10 @@ mod tests {
 
             // Try to sign a message with wrong bit length (128 bits instead of 256)
             let wrong_message = vec![true; 128];
-            let result = key_manager.sign_lamport_message_by_index(&wrong_message, LamportType::SHA256, 0);
+            let result =
+                key_manager.sign_lamport_message_by_index(&wrong_message, LamportType::SHA256, 0);
 
-            assert!(
-                result.is_err(),
-                "Should fail with wrong message length"
-            );
+            assert!(result.is_err(), "Should fail with wrong message length");
 
             Ok(())
         })
@@ -7736,12 +7718,10 @@ mod tests {
 
             // Try to sign with non-existent index
             let message_bits = vec![true; 256];
-            let result = key_manager.sign_lamport_message_by_index(&message_bits, LamportType::SHA256, 99);
+            let result =
+                key_manager.sign_lamport_message_by_index(&message_bits, LamportType::SHA256, 99);
 
-            assert!(
-                result.is_err(),
-                "Should fail with invalid index"
-            );
+            assert!(result.is_err(), "Should fail with invalid index");
 
             Ok(())
         })
@@ -7760,7 +7740,11 @@ mod tests {
             let mut signatures = Vec::new();
 
             for i in 0..10 {
-                let sig = key_manager.sign_lamport_message_by_index(&message_bits, LamportType::SHA256, i)?;
+                let sig = key_manager.sign_lamport_message_by_index(
+                    &message_bits,
+                    LamportType::SHA256,
+                    i,
+                )?;
                 signatures.push(sig);
             }
 
@@ -7798,12 +7782,14 @@ mod tests {
 
             for (idx, &byte_size) in byte_sizes.iter().enumerate() {
                 let bit_length = byte_size * 8;
-                let public_key =
-                    key_manager.next_lamport(bit_length, LamportType::SHA256)?;
+                let public_key = key_manager.next_lamport(bit_length, LamportType::SHA256)?;
 
                 let message_bytes = vec![0x42u8; byte_size];
-                let signature = key_manager
-                    .sign_lamport_message_bytes_by_index(&message_bytes, LamportType::SHA256, idx as u32)?;
+                let signature = key_manager.sign_lamport_message_bytes_by_index(
+                    &message_bytes,
+                    LamportType::SHA256,
+                    idx as u32,
+                )?;
 
                 assert!(
                     lamport.verify_signature_bytes(&message_bytes, &signature, &public_key)?,
@@ -7823,25 +7809,34 @@ mod tests {
 
             // Simulate a garbled circuit with 16 wires (each needs 1-bit signature)
             let wire_count = 16;
-            let wire_keys = key_manager.next_multiple_lamport(1, LamportType::SHA256, wire_count)?;
+            let wire_keys =
+                key_manager.next_multiple_lamport(1, LamportType::SHA256, wire_count)?;
 
             // Simulate wire values
             let wire_values = vec![
-                true, false, true, true, false, false, true, false, true, false, false, true,
-                true, false, true, false,
+                true, false, true, true, false, false, true, false, true, false, false, true, true,
+                false, true, false,
             ];
 
             // Sign each wire value
             let mut signatures = Vec::new();
             for i in 0..wire_count {
-                let sig = key_manager.sign_lamport_bit_by_index(wire_values[i as usize], LamportType::SHA256, i as u32)?;
+                let sig = key_manager.sign_lamport_bit_by_index(
+                    wire_values[i as usize],
+                    LamportType::SHA256,
+                    i as u32,
+                )?;
                 signatures.push(sig);
             }
 
             // Verify all wire signatures
             for i in 0..wire_count {
                 assert!(
-                    lamport.verify_signature_bit(wire_values[i as usize], &signatures[i as usize], &wire_keys[i as usize])?,
+                    lamport.verify_signature_bit(
+                        wire_values[i as usize],
+                        &signatures[i as usize],
+                        &wire_keys[i as usize]
+                    )?,
                     "Wire {} signature should verify",
                     i
                 );
@@ -7880,13 +7875,22 @@ mod tests {
             // All should work independently
             let message_bits = vec![true; 160];
 
-            let sig1 = key_manager.sign_lamport_message_by_index(&message_bits, LamportType::SHA256, 0)?;
+            let sig1 =
+                key_manager.sign_lamport_message_by_index(&message_bits, LamportType::SHA256, 0)?;
             assert!(lamport.verify_signature(&message_bits, &sig1, &key_sha256)?);
 
-            let sig2 = key_manager.sign_lamport_message_by_index(&message_bits, LamportType::RIPEMD160, 1)?;
+            let sig2 = key_manager.sign_lamport_message_by_index(
+                &message_bits,
+                LamportType::RIPEMD160,
+                1,
+            )?;
             assert!(lamport.verify_signature(&message_bits, &sig2, &key_ripemd160)?);
 
-            let sig3 = key_manager.sign_lamport_message_by_index(&message_bits, LamportType::HASH160, 2)?;
+            let sig3 = key_manager.sign_lamport_message_by_index(
+                &message_bits,
+                LamportType::HASH160,
+                2,
+            )?;
             assert!(lamport.verify_signature(&message_bits, &sig3, &key_hash160)?);
 
             Ok(())
@@ -7955,11 +7959,14 @@ mod tests {
             use crate::lamport::HashFunction;
 
             let message_bit_length = 128;
-            let _public_key =
-                key_manager.next_lamport(message_bit_length, LamportType::HASH160)?;
+            let _public_key = key_manager.next_lamport(message_bit_length, LamportType::HASH160)?;
 
             let message_bits = vec![true; message_bit_length];
-            let signature = key_manager.sign_lamport_message_by_index(&message_bits, LamportType::HASH160, 0)?;
+            let signature = key_manager.sign_lamport_message_by_index(
+                &message_bits,
+                LamportType::HASH160,
+                0,
+            )?;
 
             // Test signature properties
             assert_eq!(signature.len(), message_bit_length);
@@ -7996,7 +8003,11 @@ mod tests {
 
             for &idx in &test_indices {
                 let message_bits = vec![(idx % 2) == 0; 256];
-                let signature = key_manager.sign_lamport_message_by_index(&message_bits, LamportType::SHA256, idx)?;
+                let signature = key_manager.sign_lamport_message_by_index(
+                    &message_bits,
+                    LamportType::SHA256,
+                    idx,
+                )?;
 
                 assert!(
                     lamport.verify_signature(&message_bits, &signature, &keys[idx as usize])?,

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -320,6 +320,33 @@ impl KeyManager {
         Ok(rsa_pubkey_pem)
     }
 
+    pub fn import_lamport_private_key_sha_256(
+        &self,
+        private_key_0s: Zeroizing<Vec<[u8; 32]>>, // Vector of private key parts representing the value 0
+        private_key_1s: Zeroizing<Vec<[u8; 32]>>, // Vector of private key parts representing the value 1
+    ) -> Result<(Vec<[u8; 32]>, Vec<[u8; 32]>), KeyManagerError> { // Returns the corresponding public key parts
+        if private_key_0s.len() != private_key_1s.len() {
+            return Err(KeyManagerError::InvalidLamportPrivateKey);
+        }
+
+        let mut public_key_0s: Vec<[u8; 32]> = Vec::new();
+        let mut public_key_1s: Vec<[u8; 32]> = Vec::new();
+
+        for i in 0..private_key_0s.len() {
+            let pub_0s = hashes::sha256::Hash::hash(&private_key_0s[i]).to_byte_array();
+            public_key_0s.push(pub_0s);
+
+            let pub_1s = hashes::sha256::Hash::hash(&private_key_1s[i]).to_byte_array();
+            public_key_1s.push(pub_1s);
+        }
+
+        self.keystore.store_lamport_key_sha256(private_key_0s, private_key_1s, public_key_0s.clone(), public_key_1s.clone())?;
+        // store the lamport keys in a way that we can retrieve them for signing
+        // TODO mark them as used after signing to prevent reuse, ambiguous for imports. we don't know if it was already used before importing???
+
+        Ok((public_key_0s, public_key_1s))
+    }
+
     /*********************************/
     /****** Derivation path **********/
     /*********************************/
@@ -1206,6 +1233,92 @@ impl KeyManager {
             public_key.key_type(),
             public_key.derivation_index()?,
         )
+    }
+
+    // Use this fn if you want to sign an arbitrary lenght message, but take in mind that this is gruped by bytes,
+    // so you might neer to use padding, for the message and also when generating the keys
+    pub fn sign_lamport_raw_message_by_pubkey_sha256(
+        &self,
+        message_bytes: &[u8],
+        public_key_0s: Vec<[u8; 32]>,
+        public_key_1s: Vec<[u8; 32]>,
+    ) -> Result<Vec<[u8; 32]>, KeyManagerError> {
+
+        let (private_key_0s, private_key_1s) = self.keystore
+            .load_lamport_key_sha256(public_key_0s, public_key_1s)?
+            .ok_or(KeyManagerError::LamportKeyNotFound)?;
+
+        let message_bits_length = message_bytes.len() * 8; // number of bits in the message
+        // Check that private key len is equal to message_bytes quantity of bits (8 bits per byte)
+        if private_key_0s.len() != message_bits_length || private_key_1s.len() != message_bits_length {
+            return Err(KeyManagerError::InvalidLamportPrivateKey);
+        }
+
+        let mut sig = Vec::with_capacity(message_bits_length);
+
+        // Iterate through each byte in the message
+        for byte in message_bytes.iter() {
+            // Process each bit in the byte (from most significant to least significant)
+            for bit_index in 0..8 {
+                // Example for first iteration (bit_index=0) with byte = 0b10110011:
+                // - byte >> (7 - 0) = 0b10110011 >> 7 = 0b00000001 (shift MSB to rightmost position)
+                // - mask: & 1 = & 0b00000001 (isolate the rightmost bit)
+                // - result: 0b00000001 & 0b00000001 = 1
+                // - bit = 1 (extracts the MSB)
+                let bit = (byte >> (7 - bit_index)) & 1;
+                let key_index = sig.len(); // Current position = number of keys already added
+
+                if bit == 1 {
+                    sig.push(private_key_1s[key_index]);
+                } else {
+                    sig.push(private_key_0s[key_index]);
+                }
+            }
+        }
+
+        Ok(sig)
+    }
+
+    // SHA-256 Lamport: expects 32-byte message digest
+    // Also could be used to group 256 garbled circuit wire labels in one signature, where each bit represent a label
+    pub fn sign_lamport_message_digest_by_pubkey_sha256(
+        &self,
+        message_bytes: &[u8; 32], // SHA-256 outputs a [u8; 32] in big-endian byte order according to the specification
+        public_key_0s: Vec<[u8; 32]>,
+        public_key_1s: Vec<[u8; 32]>,
+    ) -> Result<Vec<[u8; 32]>, KeyManagerError> {
+        // Simply delegate to the raw message signing method
+        self.sign_lamport_raw_message_by_pubkey_sha256(message_bytes, public_key_0s, public_key_1s)
+    }
+
+    // Can be used to sign a simple garbled circuit wire label
+    pub fn sign_lamport_bit_by_pubkey_sha256(
+        &self,
+        bit: bool, // bool representing a bit false = 0, true = 1
+        public_key_0: [u8; 32],
+        public_key_1: [u8; 32],
+    ) -> Result<[u8; 32], KeyManagerError> {
+
+        let public_key_0s = vec![public_key_0];
+        let public_key_1s = vec![public_key_1];
+
+        let (private_key_0s, private_key_1s) = self.keystore
+            .load_lamport_key_sha256(public_key_0s, public_key_1s)?
+            .ok_or(KeyManagerError::LamportKeyNotFound)?;
+
+        // Validate that we retrieved the expected number of private keys
+        if private_key_0s.len() != 1 || private_key_1s.len() != 1 {
+            return Err(KeyManagerError::InvalidLamportPrivateKey);
+        }
+
+        // Get signature based on bit value
+        let sig = if bit {
+            private_key_1s[0]
+        } else {
+            private_key_0s[0]
+        };
+
+        Ok(sig)
     }
 
     /// Exports the private key for a given public key.

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -1603,7 +1603,7 @@ impl KeyManager {
         }
 
         let lamport = Lamport::new();
-        let sig = lamport.sign_message_bytes(message_bytes, &private_key)?;
+        let sig = lamport.sign_message(message_bytes, &private_key)?;
 
         self.commit_transaction(tx_id)?;
         Ok(sig)
@@ -1643,7 +1643,7 @@ impl KeyManager {
             }
         }
 
-        let signature = lamport.sign_message_bytes(message_bytes, &private_key)?;
+        let signature = lamport.sign_message(message_bytes, &private_key)?;
 
         self.commit_transaction(tx_id)?;
         Ok(signature)
@@ -1713,7 +1713,7 @@ impl KeyManager {
         }
 
         let lamport = Lamport::new();
-        let sig = lamport.sign_message_bit(message_bit, &private_key)?;
+        let sig = lamport.sign_message(message_bit, &private_key)?;
 
         self.commit_transaction(tx_id)?;
         Ok(sig)
@@ -1753,7 +1753,7 @@ impl KeyManager {
             }
         }
 
-        let signature = lamport.sign_message_bit(message_bit, &private_key)?;
+        let signature = lamport.sign_message(message_bit, &private_key)?;
 
         self.commit_transaction(tx_id)?;
         Ok(signature)

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -8094,4 +8094,97 @@ mod tests {
             Ok(())
         })
     }
+
+    #[test]
+    fn test_lamport_10bit_sign_with_bits_and_bytes() -> Result<(), KeyManagerError> {
+        let lamport = Lamport::new();
+        let message_bit_length = 10;
+
+        // Create a 10-bit message: [1, 0, 1, 0, 1, 0, 1, 0, 1, 0]
+        let message_bits: Vec<bool> = vec![true, false, true, false, true, false, true, false, true, false];
+
+        // Convert to bytes using Lamport's bits_to_bytes function (adds padding)
+        // 10 bits requires 6 padding bits to reach 16 bits (2 bytes)
+        let (message_bytes, padding) = crate::lamport::bits_to_bytes(&message_bits)?;
+        assert_eq!(padding, 6, "10 bits should require 6 bits of padding to reach 16 bits");
+        assert_eq!(message_bytes.len(), 2, "10 bits + 6 padding = 16 bits = 2 bytes");
+
+        // Use a fixed mnemonic for reproducibility
+        let test_mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+        let test_passphrase = "test_passphrase_10bit";
+
+        // Set up first key manager
+        let (keystore1, store1, keystore_path1, store_path1) = setup_test_environment()?;
+        let key_manager_config = TestKeyManagerConfig::new(
+            "regtest".to_string(),
+            Some(test_mnemonic.to_string()),
+            Some(test_passphrase.to_string()),
+        );
+        let key_manager1 = create_key_manager_from_config(&key_manager_config, keystore1, store1)?;
+
+        // Derive a key for 10-bit message at index 0
+        let public_key = key_manager1.derive_lamport(message_bit_length, LamportType::SHA256, 0)?;
+
+        // Sign using the bit-based method - THIS IS THE CORRECT METHOD for non-byte-aligned messages
+        let signature1 = key_manager1.sign_lamport_message_by_pubkey(&message_bits, &public_key)?;
+
+        // Verify the first signature
+        assert!(
+            lamport.verify_signature(&message_bits, &signature1, &public_key)?,
+            "Signature should verify with bit-based method"
+        );
+
+        // Clean up first key manager
+        drop(key_manager1);
+
+        // Set up second key manager with the same mnemonic but different storage
+        let (keystore2, store2, keystore_path2, store_path2) = setup_test_environment()?;
+        let key_manager2 = create_key_manager_from_config(&key_manager_config, keystore2, store2)?;
+
+        // Derive the same key (index 0, 10-bit message) - not marked as used in this storage
+        let public_key2 = key_manager2.derive_lamport(message_bit_length, LamportType::SHA256, 0)?;
+
+        // Verify we got the same public key
+        assert_eq!(
+            public_key.to_bytes(),
+            public_key2.to_bytes(),
+            "Public keys should match with same derivation parameters"
+        );
+
+        // IMPORTANT: Try to sign using the bytes-based method
+        // This SHOULD FAIL with MessageLengthMismatch because:
+        // - The public key is configured for 10-bit messages
+        // - message_bytes contains 2 bytes = 16 bits (including 6 padding bits)
+        // - 16 bits ≠ 10 bits → MessageLengthMismatch
+        //
+        // For message lengths that are NOT multiples of 8 bits, users MUST use:
+        // - sign_lamport_message_by_pubkey (bit-based method) ✓
+        //
+        // The byte-based method (sign_lamport_message_bytes_by_pubkey) is ONLY for:
+        // - Message lengths that are exact multiples of 8 bits (e.g., 8, 16, 24, 32, 256 bits)
+        let result = key_manager2.sign_lamport_message_bytes_by_pubkey(&message_bytes, &public_key2);
+
+        // Assert that we get the expected MessageLengthMismatch error
+        assert!(
+            result.is_err(),
+            "Byte-based signing should fail for 10-bit message (not byte-aligned)"
+        );
+
+        match result {
+            Err(KeyManagerError::LamportGenerationError(
+                crate::errors::LamportError::MessageLengthMismatch(got, expected)
+            )) => {
+                assert_eq!(got, 16, "Got 16 bits from 2 bytes");
+                assert_eq!(expected, 10, "Expected 10 bits from key configuration");
+            }
+            _ => panic!("Expected MessageLengthMismatch error, got: {:?}", result),
+        }
+
+        // Clean up
+        drop(key_manager2);
+        cleanup_test_environment(&keystore_path1, &store_path1);
+        cleanup_test_environment(&keystore_path2, &store_path2);
+
+        Ok(())
+    }
 }

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -21,7 +21,7 @@ use crate::{
     errors::KeyManagerError,
     key_store::KeyStore,
     key_type::BitcoinKeyType,
-    lamport::{Lamport, LamportPrivateKey, LamportPublicKey, LamportSignature, LamportType},
+    lamport::{Lamport, LamportMessage, LamportPrivateKey, LamportPublicKey, LamportSignature, LamportType},
     musig2::{
         errors::Musig2SignerError,
         musig::{MuSig2Signer, MuSig2SignerApi},
@@ -29,8 +29,7 @@ use crate::{
     },
     rsa::{CryptoRng, OsRng, RSAKeyPair, Signature},
     winternitz::{
-        self, checksum_length, to_checksummed_message, WinternitzPublicKey, WinternitzSignature,
-        WinternitzType,
+        self, WinternitzPublicKey, WinternitzSignature, WinternitzType, checksum_length, to_checksummed_message
     },
 };
 
@@ -1429,8 +1428,13 @@ impl KeyManager {
 
     /// Sign a message
     ///
+    /// Accepts any message type that implements [`LamportMessage`]:
+    /// - `bool` — sign a single-bit message
+    /// - `&[bool]` / `&Vec<bool>` / `&[bool; N]` — sign a multi-bit message
+    /// - `&[u8]` / `&Vec<u8>` / `&[u8; N]` — sign a byte message (converted to bits internally)
+    ///
     /// # Arguments
-    /// * `message_bits` - The message to sign as a vector of bits (boolean array 0=false, 1=true)
+    /// * `message` - The message to sign
     /// * `public_key` - The public key to retrieve the private and use that for signing
     ///
     /// # Returns
@@ -1439,13 +1443,13 @@ impl KeyManager {
     /// # Security Critical
     /// After calling this function, the private key MUST be marked as used and never reused.
     /// Reusing a Lamport private key allows attackers to forge signatures.
-    pub fn sign_lamport_message_by_pubkey(
+    pub fn sign_lamport_message_by_pubkey<M: LamportMessage>(
         &self,
-        message_bits: &[bool],
+        message: M,
         public_key: &LamportPublicKey,
     ) -> Result<LamportSignature, KeyManagerError> {
         if public_key.imported() {
-            self.sign_lamport_message_by_pubkey_imported(message_bits, public_key)
+            self.sign_lamport_message_by_pubkey_imported(message, public_key)
         } else {
             let index = public_key
                 .derivation_index()
@@ -1453,6 +1457,7 @@ impl KeyManager {
 
             // Validate message length matches the public key's expected message bit length
             let expected_bit_length = public_key.message_bit_length()?;
+            let message_bits = message.clone().into_message_bits();
             if message_bits.len() != expected_bit_length {
                 return Err(KeyManagerError::LamportGenerationError(
                     crate::errors::LamportError::MessageLengthMismatch(
@@ -1462,14 +1467,14 @@ impl KeyManager {
                 ));
             }
 
-            self.sign_lamport_message_by_index(message_bits, public_key.hash_type(), index)
+            self.sign_lamport_message_by_index(message, public_key.hash_type(), index)
         }
     }
 
     // private
-    fn sign_lamport_message_by_pubkey_imported(
+    fn sign_lamport_message_by_pubkey_imported<M: LamportMessage>(
         &self,
-        message_bits: &[bool],
+        message: M,
         public_key: &LamportPublicKey,
     ) -> Result<LamportSignature, KeyManagerError> {
         let private_key = self
@@ -1492,7 +1497,7 @@ impl KeyManager {
         }
 
         let lamport = Lamport::new();
-        let sig = lamport.sign_message(message_bits, &private_key)?;
+        let sig = lamport.sign_message(message, &private_key)?;
 
         self.commit_transaction(tx_id)?;
         Ok(sig)
@@ -1502,14 +1507,15 @@ impl KeyManager {
     /*  if this method is used directly, its the responsibility of the caller to check that the message bits lenght
         is equal to the one specified in the public key, otherwise we are signing with a virtually extended key
     */
-    fn sign_lamport_message_by_index(
+    fn sign_lamport_message_by_index<M: LamportMessage>(
         &self,
-        message_bits: &[bool],
+        message: M,
         key_type: LamportType,
         index: u32,
     ) -> Result<LamportSignature, KeyManagerError> {
         let master_secret = self.keystore.load_lamport_seed()?;
         let lamport = Lamport::new();
+        let message_bits = message.clone().into_message_bits();
         let private_key =
             lamport.generate_private_key(&*master_secret, key_type, message_bits.len(), index)?;
 
@@ -1528,232 +1534,7 @@ impl KeyManager {
             }
         }
 
-        let signature = lamport.sign_message(message_bits, &private_key)?;
-
-        self.commit_transaction(tx_id)?;
-        Ok(signature)
-    }
-
-    /// Sign a message from bytes
-    ///
-    /// # Arguments
-    /// * `message_bytes` - The message to sign as bytes
-    /// * `public_key` - The public key to retrieve the private and use that for signing
-    ///
-    /// # Returns
-    /// The signature containing the revealed private key fragments
-    ///
-    /// # Security Critical
-    /// After calling this function, the private key MUST be marked as used and never reused.
-    /// Reusing a Lamport private key allows attackers to forge signatures.
-    ///
-    /// Use example: a SHA-256 Lamport usually expects 32-byte message digest (result of the sha 256)
-    /// Also could be used to group 256 garbled circuit wire labels in one signature, where each bit represent a label
-    pub fn sign_lamport_message_bytes_by_pubkey(
-        &self,
-        message_bytes: &[u8],
-        public_key: &LamportPublicKey,
-    ) -> Result<LamportSignature, KeyManagerError> {
-        if public_key.imported() {
-            self.sign_lamport_message_bytes_by_pubkey_imported(message_bytes, public_key)
-        } else {
-            let index = public_key
-                .derivation_index()
-                .ok_or(KeyManagerError::LamportKeyDerivationIndexNotFound)?;
-
-            // Validate message length matches the public key's expected message bit length
-            let expected_bit_length = public_key.message_bit_length()?;
-            let message_bit_length = message_bytes.len() * 8;
-            if message_bit_length != expected_bit_length {
-                return Err(KeyManagerError::LamportGenerationError(
-                    crate::errors::LamportError::MessageLengthMismatch(
-                        message_bit_length,
-                        expected_bit_length,
-                    ),
-                ));
-            }
-
-            self.sign_lamport_message_bytes_by_index(message_bytes, public_key.hash_type(), index)
-        }
-    }
-
-    // private
-    fn sign_lamport_message_bytes_by_pubkey_imported(
-        &self,
-        message_bytes: &[u8],
-        public_key: &LamportPublicKey,
-    ) -> Result<LamportSignature, KeyManagerError> {
-        let private_key = self
-            .keystore
-            .load_lamport_imported_key(public_key)?
-            .ok_or(KeyManagerError::LamportKeyNotFound)?;
-
-        let tx_id = self.begin_transaction();
-        // check if index was already used, if its error, if not mark and save
-        #[cfg(feature = "lamport_idx_check")]
-        match self
-            .keystore
-            .check_and_mark_lamport_used_imported(public_key, tx_id)
-        {
-            Ok(()) => {}
-            Err(e) => {
-                self.rollback_transaction(tx_id)?;
-                return Err(e);
-            }
-        }
-
-        let lamport = Lamport::new();
-        let sig = lamport.sign_message(message_bytes, &private_key)?;
-
-        self.commit_transaction(tx_id)?;
-        Ok(sig)
-    }
-
-    // For one-time lamport keys
-    /*  if this method is used directly, its the responsibility of the caller to check that the message bits lenght
-        is equal to the one specified in the public key, otherwise we are signing with a virtually extended key
-    */
-    fn sign_lamport_message_bytes_by_index(
-        &self,
-        message_bytes: &[u8],
-        key_type: LamportType,
-        index: u32,
-    ) -> Result<LamportSignature, KeyManagerError> {
-        let master_secret = self.keystore.load_lamport_seed()?;
-        let lamport = Lamport::new();
-        let private_key = lamport.generate_private_key(
-            &*master_secret,
-            key_type,
-            message_bytes.len() * 8, // Convert bytes to bits
-            index,
-        )?;
-
-        let tx_id = self.begin_transaction();
-
-        // check if index was already used, if its error, if not mark and save
-        #[cfg(feature = "lamport_idx_check")]
-        match self
-            .keystore
-            .check_and_mark_lamport_index_used_derivated(index, tx_id)
-        {
-            Ok(()) => {}
-            Err(e) => {
-                self.rollback_transaction(tx_id)?;
-                return Err(e);
-            }
-        }
-
-        let signature = lamport.sign_message(message_bytes, &private_key)?;
-
-        self.commit_transaction(tx_id)?;
-        Ok(signature)
-    }
-
-    /// Sign a single bit
-    ///
-    /// # Arguments
-    /// * `message_bit` - The single bit to sign - bool representing a bit false = 0, true = 1
-    /// * `public_key` - The public key to retrieve the private and use that for signing
-    ///
-    /// # Returns
-    /// The signature containing the revealed private key fragment
-    ///
-    /// # Security Critical
-    /// After calling this function, the private key MUST be marked as used and never reused.
-    /// Reusing a Lamport private key allows attackers to forge signatures.
-    ///
-    /// Example use case: to sign a simple garbled circuit wire label
-    pub fn sign_lamport_bit_by_pubkey(
-        &self,
-        message_bit: bool, // bool representing a bit false = 0, true = 1
-        public_key: &LamportPublicKey,
-    ) -> Result<LamportSignature, KeyManagerError> {
-        if public_key.imported() {
-            self.sign_lamport_bit_by_pubkey_imported(message_bit, public_key)
-        } else {
-            let index = public_key
-                .derivation_index()
-                .ok_or(KeyManagerError::LamportKeyDerivationIndexNotFound)?;
-
-            // Validate message length matches the public key's expected message bit length
-            let expected_bit_length = public_key.message_bit_length()?;
-            if expected_bit_length != 1 {
-                return Err(KeyManagerError::LamportGenerationError(
-                    crate::errors::LamportError::MessageLengthMismatch(1, expected_bit_length),
-                ));
-            }
-
-            self.sign_lamport_bit_by_index(message_bit, public_key.hash_type(), index)
-        }
-    }
-
-    // private
-    fn sign_lamport_bit_by_pubkey_imported(
-        &self,
-        message_bit: bool, // bool representing a bit false = 0, true = 1
-        public_key: &LamportPublicKey,
-    ) -> Result<LamportSignature, KeyManagerError> {
-        let private_key = self
-            .keystore
-            .load_lamport_imported_key(public_key)?
-            .ok_or(KeyManagerError::LamportKeyNotFound)?;
-
-        let tx_id = self.begin_transaction();
-        // check if index was already used, if its error, if not mark and save
-        #[cfg(feature = "lamport_idx_check")]
-        match self
-            .keystore
-            .check_and_mark_lamport_used_imported(public_key, tx_id)
-        {
-            Ok(()) => {}
-            Err(e) => {
-                self.rollback_transaction(tx_id)?;
-                return Err(e);
-            }
-        }
-
-        let lamport = Lamport::new();
-        let sig = lamport.sign_message(message_bit, &private_key)?;
-
-        self.commit_transaction(tx_id)?;
-        Ok(sig)
-    }
-
-    // For one-time lamport keys
-    /*  if this method is used directly, its the responsibility of the caller to check that the message bits lenght
-        is equal to the one specified in the public key, otherwise we are signing with a virtually extended key
-    */
-    fn sign_lamport_bit_by_index(
-        &self,
-        message_bit: bool,
-        key_type: LamportType,
-        index: u32,
-    ) -> Result<LamportSignature, KeyManagerError> {
-        let master_secret = self.keystore.load_lamport_seed()?;
-        let lamport = Lamport::new();
-        let private_key = lamport.generate_private_key(
-            &*master_secret,
-            key_type,
-            1, // Single bit
-            index,
-        )?;
-
-        let tx_id = self.begin_transaction();
-
-        // check if index was already used, if its error, if not mark and save
-        #[cfg(feature = "lamport_idx_check")]
-        match self
-            .keystore
-            .check_and_mark_lamport_index_used_derivated(index, tx_id)
-        {
-            Ok(()) => {}
-            Err(e) => {
-                self.rollback_transaction(tx_id)?;
-                return Err(e);
-            }
-        }
-
-        let signature = lamport.sign_message(message_bit, &private_key)?;
+        let signature = lamport.sign_message(message, &private_key)?;
 
         self.commit_transaction(tx_id)?;
         Ok(signature)
@@ -7230,7 +7011,7 @@ mod tests {
             rng.fill_bytes(&mut message_bytes);
 
             let signature =
-                key_manager.sign_lamport_message_bytes_by_pubkey(&message_bytes, &public_key)?;
+                key_manager.sign_lamport_message_by_pubkey(&message_bytes, &public_key)?;
 
             // Verify the signature
             assert!(
@@ -7268,7 +7049,7 @@ mod tests {
                     LamportType::SHA256,
                 )?;
 
-                let signature = key_manager.sign_lamport_bit_by_pubkey(bit_value, &public_key)?;
+                let signature = key_manager.sign_lamport_message_by_pubkey(bit_value, &public_key)?;
 
                 assert_eq!(
                     signature.message_bit_length(),
@@ -7467,7 +7248,7 @@ mod tests {
 
             // Sign a 32-byte message using index
             let message_bytes = [0x42u8; 32];
-            let signature = key_manager.sign_lamport_message_bytes_by_index(
+            let signature = key_manager.sign_lamport_message_by_index(
                 &message_bytes,
                 LamportType::SHA256,
                 0,
@@ -7490,12 +7271,12 @@ mod tests {
 
             // Sign bit 0 using index 0
             let signature_0 =
-                key_manager.sign_lamport_bit_by_index(false, LamportType::SHA256, 0)?;
+                key_manager.sign_lamport_message_by_index(false, LamportType::SHA256, 0)?;
             assert!(lamport.verify_signature(false, &signature_0, &public_keys[0])?);
 
             // Sign bit 1 using index 1
             let signature_1 =
-                key_manager.sign_lamport_bit_by_index(true, LamportType::SHA256, 1)?;
+                key_manager.sign_lamport_message_by_index(true, LamportType::SHA256, 1)?;
             assert!(lamport.verify_signature(true, &signature_1, &public_keys[1])?);
 
             Ok(())
@@ -7860,7 +7641,7 @@ mod tests {
                 let public_key = key_manager.next_lamport(bit_length, LamportType::SHA256)?;
 
                 let message_bytes = vec![0x42u8; byte_size];
-                let signature = key_manager.sign_lamport_message_bytes_by_index(
+                let signature = key_manager.sign_lamport_message_by_index(
                     &message_bytes,
                     LamportType::SHA256,
                     idx as u32,
@@ -7896,7 +7677,7 @@ mod tests {
             // Sign each wire value
             let mut signatures = Vec::new();
             for i in 0..wire_count {
-                let sig = key_manager.sign_lamport_bit_by_index(
+                let sig = key_manager.sign_lamport_message_by_index(
                     wire_values[i as usize],
                     LamportType::SHA256,
                     i as u32,
@@ -8170,10 +7951,10 @@ mod tests {
         // For message lengths that are NOT multiples of 8 bits, users MUST use:
         // - sign_lamport_message_by_pubkey (bit-based method) ✓
         //
-        // The byte-based method (sign_lamport_message_bytes_by_pubkey) is ONLY for:
+        // The byte-based method, (using message_bytes)  is ONLY for:
         // - Message lengths that are exact multiples of 8 bits (e.g., 8, 16, 24, 32, 256 bits)
         let result =
-            key_manager2.sign_lamport_message_bytes_by_pubkey(&message_bytes, &public_key2);
+            key_manager2.sign_lamport_message_by_pubkey(&message_bytes, &public_key2);
 
         // Assert that we get the expected MessageLengthMismatch error
         assert!(

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -18,19 +18,13 @@ use uuid::Uuid;
 use zeroize::Zeroizing;
 
 use crate::{
-    errors::KeyManagerError,
-    key_store::KeyStore,
-    key_type::BitcoinKeyType,
-    musig2::{
+    errors::KeyManagerError, key_store::KeyStore, key_type::BitcoinKeyType, lamport::{Lamport, LamportPrivateKey, LamportPublicKey, LamportSignature}, musig2::{
         errors::Musig2SignerError,
         musig::{MuSig2Signer, MuSig2SignerApi},
         types::MessageId,
-    },
-    rsa::{CryptoRng, OsRng, RSAKeyPair, Signature},
-    winternitz::{
-        self, checksum_length, to_checksummed_message, WinternitzPublicKey, WinternitzSignature,
-        WinternitzType,
-    },
+    }, rsa::{CryptoRng, OsRng, RSAKeyPair, Signature}, winternitz::{
+        self, WinternitzPublicKey, WinternitzSignature, WinternitzType, checksum_length, to_checksummed_message
+    }
 };
 
 use musig2::{sign_partial, AggNonce, PartialSignature, PubNonce, SecNonce};
@@ -320,31 +314,18 @@ impl KeyManager {
         Ok(rsa_pubkey_pem)
     }
 
-    pub fn import_lamport_private_key_sha_256(
+    pub fn import_lamport_private_key(
         &self,
-        private_key_0s: Zeroizing<Vec<[u8; 32]>>, // Vector of private key parts representing the value 0
-        private_key_1s: Zeroizing<Vec<[u8; 32]>>, // Vector of private key parts representing the value 1
-    ) -> Result<(Vec<[u8; 32]>, Vec<[u8; 32]>), KeyManagerError> { // Returns the corresponding public key parts
-        if private_key_0s.len() != private_key_1s.len() {
-            return Err(KeyManagerError::InvalidLamportPrivateKey);
-        }
+        private_key: &LamportPrivateKey
+    ) -> Result<LamportPublicKey, KeyManagerError> { // Returns the corresponding public key
 
-        let mut public_key_0s: Vec<[u8; 32]> = Vec::new();
-        let mut public_key_1s: Vec<[u8; 32]> = Vec::new();
-
-        for i in 0..private_key_0s.len() {
-            let pub_0s = hashes::sha256::Hash::hash(&private_key_0s[i]).to_byte_array();
-            public_key_0s.push(pub_0s);
-
-            let pub_1s = hashes::sha256::Hash::hash(&private_key_1s[i]).to_byte_array();
-            public_key_1s.push(pub_1s);
-        }
-
-        self.keystore.store_lamport_key_sha256(private_key_0s, private_key_1s, public_key_0s.clone(), public_key_1s.clone())?;
+        let public_key = private_key.public_key()?;
+        self.keystore.store_lamport_key(private_key, &public_key)?;
         // store the lamport keys in a way that we can retrieve them for signing
         // TODO mark them as used after signing to prevent reuse, ambiguous for imports. we don't know if it was already used before importing???
+        // TODO for imports also track if already used to signpublic_key, even if we don't know its past (discussed with Martin)
 
-        Ok((public_key_0s, public_key_1s))
+        Ok(public_key)
     }
 
     /*********************************/
@@ -1235,89 +1216,88 @@ impl KeyManager {
         )
     }
 
-    // Use this fn if you want to sign an arbitrary lenght message, but take in mind that this is gruped by bytes,
-    // so you might neer to use padding, for the message and also when generating the keys
-    pub fn sign_lamport_raw_message_by_pubkey_sha256(
+    /// Sign a message
+    ///
+    /// # Arguments
+    /// * `message_bits` - The message to sign as a vector of bits (boolean array 0=false, 1=true)
+    /// * `public_key` - The public key to retrieve the private and use that for signing
+    ///
+    /// # Returns
+    /// The signature containing the revealed private key fragments
+    ///
+    /// # Security Critical
+    /// After calling this function, the private key MUST be marked as used and never reused.
+    /// Reusing a Lamport private key allows attackers to forge signatures.
+    pub fn sign_lamport_message_by_pubkey(
         &self,
-        message_bytes: &[u8],
-        public_key_0s: Vec<[u8; 32]>,
-        public_key_1s: Vec<[u8; 32]>,
-    ) -> Result<Vec<[u8; 32]>, KeyManagerError> {
+        message_bits: &[bool],
+        public_key: &LamportPublicKey
+    ) -> Result<LamportSignature, KeyManagerError> {
 
-        let (private_key_0s, private_key_1s) = self.keystore
-            .load_lamport_key_sha256(public_key_0s, public_key_1s)?
+        let private_key = self.keystore
+            .load_lamport_key(public_key)?
             .ok_or(KeyManagerError::LamportKeyNotFound)?;
 
-        let message_bits_length = message_bytes.len() * 8; // number of bits in the message
-        // Check that private key len is equal to message_bytes quantity of bits (8 bits per byte)
-        if private_key_0s.len() != message_bits_length || private_key_1s.len() != message_bits_length {
-            return Err(KeyManagerError::InvalidLamportPrivateKey);
-        }
-
-        let mut sig = Vec::with_capacity(message_bits_length);
-
-        // Iterate through each byte in the message
-        for byte in message_bytes.iter() {
-            // Process each bit in the byte (from most significant to least significant)
-            for bit_index in 0..8 {
-                // Example for first iteration (bit_index=0) with byte = 0b10110011:
-                // - byte >> (7 - 0) = 0b10110011 >> 7 = 0b00000001 (shift MSB to rightmost position)
-                // - mask: & 1 = & 0b00000001 (isolate the rightmost bit)
-                // - result: 0b00000001 & 0b00000001 = 1
-                // - bit = 1 (extracts the MSB)
-                let bit = (byte >> (7 - bit_index)) & 1;
-                let key_index = sig.len(); // Current position = number of keys already added
-
-                if bit == 1 {
-                    sig.push(private_key_1s[key_index]);
-                } else {
-                    sig.push(private_key_0s[key_index]);
-                }
-            }
-        }
-
+        let lamport = Lamport::new();
+        let sig = lamport.sign_message(message_bits, &private_key)?;
         Ok(sig)
     }
 
-    // SHA-256 Lamport: expects 32-byte message digest
-    // Also could be used to group 256 garbled circuit wire labels in one signature, where each bit represent a label
-    pub fn sign_lamport_message_digest_by_pubkey_sha256(
+    /// Sign a message from bytes
+    ///
+    /// # Arguments
+    /// * `message_bytes` - The message to sign as bytes
+    /// * `public_key` - The public key to retrieve the private and use that for signing
+    ///
+    /// # Returns
+    /// The signature containing the revealed private key fragments
+    ///
+    /// # Security Critical
+    /// After calling this function, the private key MUST be marked as used and never reused.
+    /// Reusing a Lamport private key allows attackers to forge signatures.
+    ///
+    /// Use example: a SHA-256 Lamport usually expects 32-byte message digest (result of the sha 256)
+    /// Also could be used to group 256 garbled circuit wire labels in one signature, where each bit represent a label
+    pub fn sign_lamport_message_bytes_by_pubkey(
         &self,
-        message_bytes: &[u8; 32], // SHA-256 outputs a [u8; 32] in big-endian byte order according to the specification
-        public_key_0s: Vec<[u8; 32]>,
-        public_key_1s: Vec<[u8; 32]>,
-    ) -> Result<Vec<[u8; 32]>, KeyManagerError> {
-        // Simply delegate to the raw message signing method
-        self.sign_lamport_raw_message_by_pubkey_sha256(message_bytes, public_key_0s, public_key_1s)
-    }
-
-    // Can be used to sign a simple garbled circuit wire label
-    pub fn sign_lamport_bit_by_pubkey_sha256(
-        &self,
-        bit: bool, // bool representing a bit false = 0, true = 1
-        public_key_0: [u8; 32],
-        public_key_1: [u8; 32],
-    ) -> Result<[u8; 32], KeyManagerError> {
-
-        let public_key_0s = vec![public_key_0];
-        let public_key_1s = vec![public_key_1];
-
-        let (private_key_0s, private_key_1s) = self.keystore
-            .load_lamport_key_sha256(public_key_0s, public_key_1s)?
+        message_bytes: &[u8],
+        public_key: &LamportPublicKey
+    ) -> Result<LamportSignature, KeyManagerError> {
+        let private_key = self.keystore
+            .load_lamport_key(public_key)?
             .ok_or(KeyManagerError::LamportKeyNotFound)?;
 
-        // Validate that we retrieved the expected number of private keys
-        if private_key_0s.len() != 1 || private_key_1s.len() != 1 {
-            return Err(KeyManagerError::InvalidLamportPrivateKey);
-        }
+        let lamport = Lamport::new();
+        let sig = lamport.sign_message_bytes(message_bytes, &private_key)?;
+        Ok(sig)
+    }
 
-        // Get signature based on bit value
-        let sig = if bit {
-            private_key_1s[0]
-        } else {
-            private_key_0s[0]
-        };
+    /// Sign a single bit
+    ///
+    /// # Arguments
+    /// * `message_bit` - The single bit to sign - bool representing a bit false = 0, true = 1
+    /// * `public_key` - The public key to retrieve the private and use that for signing
+    ///
+    /// # Returns
+    /// The signature containing the revealed private key fragment
+    ///
+    /// # Security Critical
+    /// After calling this function, the private key MUST be marked as used and never reused.
+    /// Reusing a Lamport private key allows attackers to forge signatures.
+    ///
+    /// Example use case: to sign a simple garbled circuit wire label
+    pub fn sign_lamport_bit_by_pubkey(
+        &self,
+        message_bit: bool, // bool representing a bit false = 0, true = 1
+        public_key: &LamportPublicKey
+    ) -> Result<LamportSignature, KeyManagerError> {
 
+        let private_key = self.keystore
+            .load_lamport_key(public_key)?
+            .ok_or(KeyManagerError::LamportKeyNotFound)?;
+
+        let lamport = Lamport::new();
+        let sig = lamport.sign_message_bit(message_bit, &private_key)?;
         Ok(sig)
     }
 

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -1485,6 +1485,7 @@ impl KeyManager {
     }
 
     // For one-time lamport keys
+    // TODO: make this fun private to force sign by key? Protocol should store the key and not the index
     pub fn sign_lamport_message_by_index(
         &self,
         message_bits: &[bool],
@@ -1587,7 +1588,9 @@ impl KeyManager {
             Ok(sig)
     }
 
+
     // For one-time lamport keys
+    // TODO: make this fun private to force sign by key? Protocol should store the key and not the index
     pub fn sign_lamport_message_bytes_by_index(
         &self,
         message_bytes: &[u8],
@@ -1690,6 +1693,7 @@ impl KeyManager {
     }
 
     // For one-time lamport keys
+    // TODO: make this fun private to force sign by key? Protocol should store the key and not the index
     pub fn sign_lamport_bit_by_index(
         &self,
         message_bit: bool,
@@ -3137,6 +3141,15 @@ mod tests {
         )?;
         keystore.store_winternitz_seed(winternitz_seed)?;
 
+        // Initialize Lamport seed
+        let lamport_seed = KeyManager::derive_lamport_master_seed(
+            secp.clone(),
+            &*key_derivation_seed,
+            REGTEST,
+            KeyManager::ACCOUNT_DERIVATION_INDEX,
+        )?;
+        keystore.store_lamport_seed(lamport_seed)?;
+
         let musig2 = MuSig2Signer::new(store);
 
         Ok(KeyManager {
@@ -3244,6 +3257,15 @@ mod tests {
             KeyManager::ACCOUNT_DERIVATION_INDEX,
         )?;
         keystore.store_winternitz_seed(winternitz_seed)?;
+
+        // Derive and store lamport seed
+        let lamport_seed = KeyManager::derive_lamport_master_seed(
+            secp.clone(),
+            &*key_derivation_seed,
+            network,
+            KeyManager::ACCOUNT_DERIVATION_INDEX,
+        )?;
+        keystore.store_lamport_seed(lamport_seed)?;
 
         let musig2 = MuSig2Signer::new(store);
 
@@ -7280,6 +7302,643 @@ mod tests {
                 assert!(
                     lamport.verify_signature(&message_bits, &signature, public_key)?,
                     "All stored keys should be retrievable and functional"
+                );
+            }
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_lamport_next_single_key_derivation() -> Result<(), KeyManagerError> {
+        run_test_with_key_manager(|key_manager| {
+            let lamport = Lamport::new();
+
+            // Derive a single Lamport key
+            let public_key = key_manager.next_lamport(256, LamportType::SHA256)?;
+
+            assert_eq!(public_key.hash_type(), LamportType::SHA256);
+            assert_eq!(public_key.len(), 256);
+            assert_eq!(public_key.message_bit_length()?, 256);
+            assert_eq!(public_key.derivation_index(), Some(0));
+            assert!(!public_key.imported());
+
+            // Sign a message with the derived key
+            let message_bits = vec![true; 256];
+            let signature =
+                key_manager.sign_lamport_message_by_pubkey(&message_bits, &public_key)?;
+
+            assert!(lamport.verify_signature(&message_bits, &signature, &public_key)?);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_lamport_next_multiple_keys_derivation() -> Result<(), KeyManagerError> {
+        run_test_with_key_manager(|key_manager| {
+            let lamport = Lamport::new();
+            let count = 5;
+
+            // Derive multiple Lamport keys at once
+            let public_keys =
+                key_manager.next_multiple_lamport(160, LamportType::HASH160, count)?;
+
+            assert_eq!(public_keys.len(), count as usize);
+
+            // Verify each key has sequential derivation index
+            for (i, public_key) in public_keys.iter().enumerate() {
+                assert_eq!(public_key.hash_type(), LamportType::HASH160);
+                assert_eq!(public_key.len(), 160);
+                assert_eq!(public_key.derivation_index(), Some(i as u32));
+                assert!(!public_key.imported());
+
+                // Sign and verify with each key
+                let message_bits = vec![false; 160];
+                let signature =
+                    key_manager.sign_lamport_message_by_pubkey(&message_bits, public_key)?;
+
+                assert!(
+                    lamport.verify_signature(&message_bits, &signature, public_key)?,
+                    "Key {} should sign and verify correctly",
+                    i
+                );
+            }
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_lamport_sign_by_index() -> Result<(), KeyManagerError> {
+        run_test_with_key_manager(|key_manager| {
+            let lamport = Lamport::new();
+
+            // Derive keys
+            let public_keys = key_manager.next_multiple_lamport(128, LamportType::SHA256, 3)?;
+
+            // Sign using index
+            let message_bits = vec![true, false, true, false].repeat(32);
+            let signature = key_manager.sign_lamport_message_by_index(&message_bits, LamportType::SHA256, 1)?;
+
+            // Verify signature
+            assert!(lamport.verify_signature(&message_bits, &signature, &public_keys[1])?);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_lamport_sign_bytes_by_index() -> Result<(), KeyManagerError> {
+        run_test_with_key_manager(|key_manager| {
+            let lamport = Lamport::new();
+
+            // Derive a key for 32-byte messages
+            let public_keys = key_manager.next_multiple_lamport(256, LamportType::SHA256, 2)?;
+
+            // Sign a 32-byte message using index
+            let message_bytes = [0x42u8; 32];
+            let signature = key_manager.sign_lamport_message_bytes_by_index(&message_bytes, LamportType::SHA256, 0)?;
+
+            // Verify signature
+            assert!(lamport.verify_signature_bytes(&message_bytes, &signature, &public_keys[0])?);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_lamport_sign_bit_by_index() -> Result<(), KeyManagerError> {
+        run_test_with_key_manager(|key_manager| {
+            let lamport = Lamport::new();
+
+            // Derive keys for single-bit signing
+            let public_keys = key_manager.next_multiple_lamport(1, LamportType::SHA256, 2)?;
+
+            // Sign bit 0 using index 0
+            let signature_0 = key_manager.sign_lamport_bit_by_index(false, LamportType::SHA256, 0)?;
+            assert!(lamport.verify_signature_bit(false, &signature_0, &public_keys[0])?);
+
+            // Sign bit 1 using index 1
+            let signature_1 = key_manager.sign_lamport_bit_by_index(true, LamportType::SHA256, 1)?;
+            assert!(lamport.verify_signature_bit(true, &signature_1, &public_keys[1])?);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_lamport_all_hash_types_with_derivation() -> Result<(), KeyManagerError> {
+        run_test_with_key_manager(|key_manager| {
+            let lamport = Lamport::new();
+
+            let test_cases = vec![
+                (LamportType::SHA256, 256),
+                (LamportType::RIPEMD160, 160),
+                (LamportType::HASH160, 160),
+                (LamportType::HASH256, 256),
+            ];
+
+            for (hash_type, message_bit_length) in test_cases {
+                let public_key = key_manager.next_lamport(message_bit_length, hash_type)?;
+
+                assert_eq!(public_key.hash_type(), hash_type);
+                assert_eq!(public_key.len(), message_bit_length);
+
+                // Sign and verify
+                let message_bits = vec![true; message_bit_length];
+                let signature =
+                    key_manager.sign_lamport_message_by_pubkey(&message_bits, &public_key)?;
+
+                assert!(
+                    lamport.verify_signature(&message_bits, &signature, &public_key)?,
+                    "Hash type {:?} should work correctly",
+                    hash_type
+                );
+            }
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_lamport_key_reuse_prevention_imported() -> Result<(), KeyManagerError> {
+        run_test_with_key_manager(|key_manager| {
+            let lamport = Lamport::new();
+            let mut rng = rand::thread_rng();
+
+            // Generate and import a key
+            let mut master_secret = [0u8; 32];
+            rng.fill_bytes(&mut master_secret);
+
+            let private_key =
+                lamport.generate_private_key(&master_secret, LamportType::SHA256, 256, 0)?;
+            let public_key = key_manager.import_lamport_private_key(&private_key)?;
+
+            // Sign once - should succeed
+            let message_bits = vec![true; 256];
+            let _signature =
+                key_manager.sign_lamport_message_by_pubkey(&message_bits, &public_key)?;
+
+            // Try to sign again - should fail (key should be marked as spent)
+            let result = key_manager.sign_lamport_message_by_pubkey(&message_bits, &public_key);
+
+            assert!(
+                result.is_err(),
+                "Should not be able to reuse an imported Lamport key"
+            );
+
+            if let Err(KeyManagerError::LamportImportedKeyAlreadyUsed) = result {
+                // Expected error
+            } else {
+                panic!("Expected LamportImportedKeyAlreadyUsed error, got {:?}", result);
+            }
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_lamport_key_reuse_prevention_derived() -> Result<(), KeyManagerError> {
+        run_test_with_key_manager(|key_manager| {
+            let _lamport = Lamport::new();
+
+            // Derive a key
+            let _public_key = key_manager.next_lamport(256, LamportType::SHA256)?;
+
+            // Sign once - should succeed
+            let message_bits = vec![false; 256];
+            let _signature = key_manager.sign_lamport_message_by_index(&message_bits, LamportType::SHA256, 0)?;
+
+            // Try to sign again with the same key - should fail
+            let result = key_manager.sign_lamport_message_by_index(&message_bits, LamportType::SHA256, 0);
+
+            assert!(
+                result.is_err(),
+                "Should not be able to reuse a derived Lamport key"
+            );
+
+            if let Err(KeyManagerError::LamportIndexAlreadyUsed(index)) = result {
+                assert_eq!(index, 0);
+            } else {
+                panic!("Expected LamportIndexAlreadyUsed error, got {:?}", result);
+            }
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_lamport_deterministic_derivation() -> Result<(), KeyManagerError> {
+        // Create two separate key managers with the same config
+        let result1 = run_test_with_key_manager(|key_manager1| {
+            let public_key1 = key_manager1.next_lamport(256, LamportType::SHA256)?;
+            Ok(public_key1.to_bytes())
+        })?;
+
+        let result2 = run_test_with_key_manager(|key_manager2| {
+            let public_key2 = key_manager2.next_lamport(256, LamportType::SHA256)?;
+            Ok(public_key2.to_bytes())
+        })?;
+
+        // Both should derive the same key for index 0
+        assert_eq!(
+            result1, result2,
+            "Lamport key derivation should be deterministic"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_lamport_sequential_index_allocation() -> Result<(), KeyManagerError> {
+        run_test_with_key_manager(|key_manager| {
+            // Derive multiple keys one by one
+            let key0 = key_manager.next_lamport(128, LamportType::SHA256)?;
+            let key1 = key_manager.next_lamport(128, LamportType::SHA256)?;
+            let key2 = key_manager.next_lamport(128, LamportType::SHA256)?;
+
+            // Verify sequential indices
+            assert_eq!(key0.derivation_index(), Some(0));
+            assert_eq!(key1.derivation_index(), Some(1));
+            assert_eq!(key2.derivation_index(), Some(2));
+
+            // All keys should be different
+            assert_ne!(key0.to_bytes(), key1.to_bytes());
+            assert_ne!(key1.to_bytes(), key2.to_bytes());
+            assert_ne!(key0.to_bytes(), key2.to_bytes());
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_lamport_varying_message_lengths() -> Result<(), KeyManagerError> {
+        run_test_with_key_manager(|key_manager| {
+            let lamport = Lamport::new();
+
+            // Test various message bit lengths
+            let bit_lengths = vec![1, 8, 64, 128, 256, 512, 1024];
+
+            for bit_length in bit_lengths {
+                let public_key = key_manager.next_lamport(bit_length, LamportType::SHA256)?;
+
+                assert_eq!(public_key.len(), bit_length);
+
+                // Sign and verify
+                let message_bits = vec![true; bit_length];
+                let signature =
+                    key_manager.sign_lamport_message_by_pubkey(&message_bits, &public_key)?;
+
+                assert!(
+                    lamport.verify_signature(&message_bits, &signature, &public_key)?,
+                    "Bit length {} should work correctly",
+                    bit_length
+                );
+            }
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_lamport_mixed_imported_and_derived_keys() -> Result<(), KeyManagerError> {
+        run_test_with_key_manager(|key_manager| {
+            let lamport = Lamport::new();
+            let mut rng = rand::thread_rng();
+
+            // Derive a key
+            let derived_key = key_manager.next_lamport(256, LamportType::SHA256)?;
+
+            // Import a key
+            let mut master_secret = [0u8; 32];
+            rng.fill_bytes(&mut master_secret);
+            let private_key =
+                lamport.generate_private_key(&master_secret, LamportType::SHA256, 256, 0)?;
+            let imported_key = key_manager.import_lamport_private_key(&private_key)?;
+
+            // Derive another key
+            let derived_key2 = key_manager.next_lamport(256, LamportType::SHA256)?;
+
+            // All keys should be different
+            assert_ne!(derived_key.to_bytes(), imported_key.to_bytes());
+            assert_ne!(imported_key.to_bytes(), derived_key2.to_bytes());
+            assert_ne!(derived_key.to_bytes(), derived_key2.to_bytes());
+
+            // Verify markers
+            assert!(!derived_key.imported());
+            assert!(imported_key.imported());
+            assert!(!derived_key2.imported());
+
+            // All should be functional
+            let message_bits = vec![true; 256];
+
+            let sig1 = key_manager.sign_lamport_message_by_pubkey(&message_bits, &derived_key)?;
+            assert!(lamport.verify_signature(&message_bits, &sig1, &derived_key)?);
+
+            let sig2 = key_manager.sign_lamport_message_by_pubkey(&message_bits, &imported_key)?;
+            assert!(lamport.verify_signature(&message_bits, &sig2, &imported_key)?);
+
+            let sig3 = key_manager.sign_lamport_message_by_pubkey(&message_bits, &derived_key2)?;
+            assert!(lamport.verify_signature(&message_bits, &sig3, &derived_key2)?);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_lamport_error_sign_with_invalid_message_length() -> Result<(), KeyManagerError> {
+        run_test_with_key_manager(|key_manager| {
+            // Derive a key for 256-bit messages
+            let _public_key = key_manager.next_lamport(256, LamportType::SHA256)?;
+
+            // Try to sign a message with wrong bit length (128 bits instead of 256)
+            let wrong_message = vec![true; 128];
+            let result = key_manager.sign_lamport_message_by_index(&wrong_message, LamportType::SHA256, 0);
+
+            assert!(
+                result.is_err(),
+                "Should fail with wrong message length"
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_lamport_error_sign_with_invalid_index() -> Result<(), KeyManagerError> {
+        run_test_with_key_manager(|key_manager| {
+            // Derive only one key (index 0)
+            let _public_key = key_manager.next_lamport(256, LamportType::SHA256)?;
+
+            // Try to sign with non-existent index
+            let message_bits = vec![true; 256];
+            let result = key_manager.sign_lamport_message_by_index(&message_bits, LamportType::SHA256, 99);
+
+            assert!(
+                result.is_err(),
+                "Should fail with invalid index"
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_lamport_multiple_signatures_different_keys() -> Result<(), KeyManagerError> {
+        run_test_with_key_manager(|key_manager| {
+            let lamport = Lamport::new();
+
+            // Derive multiple keys
+            let keys = key_manager.next_multiple_lamport(256, LamportType::SHA256, 10)?;
+
+            // Sign the same message with different keys
+            let message_bits = vec![true, false].repeat(128);
+            let mut signatures = Vec::new();
+
+            for i in 0..10 {
+                let sig = key_manager.sign_lamport_message_by_index(&message_bits, LamportType::SHA256, i)?;
+                signatures.push(sig);
+            }
+
+            // All signatures should be different (different keys used)
+            for i in 0..signatures.len() {
+                for j in (i + 1)..signatures.len() {
+                    assert_ne!(
+                        signatures[i].to_bytes(),
+                        signatures[j].to_bytes(),
+                        "Signatures from different keys should be different"
+                    );
+                }
+            }
+
+            // All signatures should verify with their respective keys
+            for (i, sig) in signatures.iter().enumerate() {
+                assert!(
+                    lamport.verify_signature(&message_bits, sig, &keys[i])?,
+                    "Signature {} should verify",
+                    i
+                );
+            }
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_lamport_bytes_signature_with_various_sizes() -> Result<(), KeyManagerError> {
+        run_test_with_key_manager(|key_manager| {
+            let lamport = Lamport::new();
+
+            // Test with different byte sizes
+            let byte_sizes = vec![1, 4, 16, 20, 32, 64];
+
+            for (idx, &byte_size) in byte_sizes.iter().enumerate() {
+                let bit_length = byte_size * 8;
+                let public_key =
+                    key_manager.next_lamport(bit_length, LamportType::SHA256)?;
+
+                let message_bytes = vec![0x42u8; byte_size];
+                let signature = key_manager
+                    .sign_lamport_message_bytes_by_index(&message_bytes, LamportType::SHA256, idx as u32)?;
+
+                assert!(
+                    lamport.verify_signature_bytes(&message_bytes, &signature, &public_key)?,
+                    "Byte size {} should work correctly",
+                    byte_size
+                );
+            }
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_lamport_garbled_circuit_use_case() -> Result<(), KeyManagerError> {
+        run_test_with_key_manager(|key_manager| {
+            let lamport = Lamport::new();
+
+            // Simulate a garbled circuit with 16 wires (each needs 1-bit signature)
+            let wire_count = 16;
+            let wire_keys = key_manager.next_multiple_lamport(1, LamportType::SHA256, wire_count)?;
+
+            // Simulate wire values
+            let wire_values = vec![
+                true, false, true, true, false, false, true, false, true, false, false, true,
+                true, false, true, false,
+            ];
+
+            // Sign each wire value
+            let mut signatures = Vec::new();
+            for i in 0..wire_count {
+                let sig = key_manager.sign_lamport_bit_by_index(wire_values[i as usize], LamportType::SHA256, i as u32)?;
+                signatures.push(sig);
+            }
+
+            // Verify all wire signatures
+            for i in 0..wire_count {
+                assert!(
+                    lamport.verify_signature_bit(wire_values[i as usize], &signatures[i as usize], &wire_keys[i as usize])?,
+                    "Wire {} signature should verify",
+                    i
+                );
+
+                // Verify that wrong bit value fails
+                assert!(
+                    !lamport.verify_signature_bit(
+                        !wire_values[i as usize],
+                        &signatures[i as usize],
+                        &wire_keys[i as usize]
+                    )?,
+                    "Wire {} should fail with wrong bit value",
+                    i
+                );
+            }
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_lamport_cross_hash_type_non_interference() -> Result<(), KeyManagerError> {
+        run_test_with_key_manager(|key_manager| {
+            let lamport = Lamport::new();
+
+            // Derive keys with different hash types but same message length
+            let key_sha256 = key_manager.next_lamport(160, LamportType::SHA256)?;
+            let key_ripemd160 = key_manager.next_lamport(160, LamportType::RIPEMD160)?;
+            let key_hash160 = key_manager.next_lamport(160, LamportType::HASH160)?;
+
+            // All should have different derivation indices
+            assert_eq!(key_sha256.derivation_index(), Some(0));
+            assert_eq!(key_ripemd160.derivation_index(), Some(1));
+            assert_eq!(key_hash160.derivation_index(), Some(2));
+
+            // All should work independently
+            let message_bits = vec![true; 160];
+
+            let sig1 = key_manager.sign_lamport_message_by_index(&message_bits, LamportType::SHA256, 0)?;
+            assert!(lamport.verify_signature(&message_bits, &sig1, &key_sha256)?);
+
+            let sig2 = key_manager.sign_lamport_message_by_index(&message_bits, LamportType::RIPEMD160, 1)?;
+            assert!(lamport.verify_signature(&message_bits, &sig2, &key_ripemd160)?);
+
+            let sig3 = key_manager.sign_lamport_message_by_index(&message_bits, LamportType::HASH160, 2)?;
+            assert!(lamport.verify_signature(&message_bits, &sig3, &key_hash160)?);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_lamport_serialization_roundtrip() -> Result<(), KeyManagerError> {
+        run_test_with_key_manager(|key_manager| {
+            // Derive a key
+            let public_key = key_manager.next_lamport(256, LamportType::SHA256)?;
+
+            // Serialize to bytes
+            let bytes = public_key.to_bytes();
+
+            // Deserialize
+            let reconstructed = crate::lamport::LamportPublicKey::from_bytes(
+                &bytes,
+                256,
+                LamportType::SHA256,
+                false,
+                Some(crate::lamport::ExtraData::new(256, Some(0))),
+            )?;
+
+            // Should match
+            assert_eq!(public_key.to_bytes(), reconstructed.to_bytes());
+            assert_eq!(public_key.hash_type(), reconstructed.hash_type());
+            assert_eq!(public_key.len(), reconstructed.len());
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_lamport_hash_output_methods() -> Result<(), KeyManagerError> {
+        run_test_with_key_manager(|key_manager| {
+            // Derive a key
+            let public_key = key_manager.next_lamport(8, LamportType::SHA256)?;
+
+            // Test different output formats
+            let (hashes_0s, hashes_1s) = public_key.to_hashes();
+            assert_eq!(hashes_0s.len(), 8);
+            assert_eq!(hashes_1s.len(), 8);
+
+            let (str_0s, str_1s) = public_key.to_hashes_string();
+            assert_eq!(str_0s.len(), 8);
+            assert_eq!(str_1s.len(), 8);
+            // SHA256 hashes should be 64 hex chars
+            for hash_str in &str_0s {
+                assert_eq!(hash_str.len(), 64);
+            }
+
+            let result = public_key.to_array_hashes();
+            assert!(result.is_ok());
+            let (arr_0s, arr_1s) = result?;
+            assert_eq!(arr_0s.len(), 8);
+            assert_eq!(arr_1s.len(), 8);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_lamport_signature_properties() -> Result<(), KeyManagerError> {
+        run_test_with_key_manager(|key_manager| {
+            use crate::lamport::HashFunction;
+
+            let message_bit_length = 128;
+            let public_key =
+                key_manager.next_lamport(message_bit_length, LamportType::HASH160)?;
+
+            let message_bits = vec![true; message_bit_length];
+            let signature = key_manager.sign_lamport_message_by_index(&message_bits, LamportType::HASH160, 0)?;
+
+            // Test signature properties
+            assert_eq!(signature.len(), message_bit_length);
+            assert!(!signature.is_empty());
+            assert_eq!(signature.message_bit_length(), message_bit_length);
+            assert_eq!(signature.hash_type(), LamportType::HASH160);
+
+            // Test serialization
+            let sig_bytes = signature.to_bytes();
+            let hash_size = LamportType::HASH160.hash_size();
+            assert_eq!(sig_bytes.len(), message_bit_length * hash_size);
+
+            // Test to_hashes method
+            let sig_hashes = signature.to_hashes();
+            assert_eq!(sig_hashes.len(), message_bit_length);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_lamport_large_batch_derivation() -> Result<(), KeyManagerError> {
+        run_test_with_key_manager(|key_manager| {
+            let lamport = Lamport::new();
+            let batch_size: u32 = 100;
+
+            // Derive a large batch
+            let keys = key_manager.next_multiple_lamport(256, LamportType::SHA256, batch_size)?;
+
+            assert_eq!(keys.len(), batch_size as usize);
+
+            // Test a few keys from the batch
+            let test_indices = vec![0, batch_size / 4, batch_size / 2, batch_size - 1];
+
+            for &idx in &test_indices {
+                let message_bits = vec![(idx % 2) == 0; 256];
+                let signature = key_manager.sign_lamport_message_by_index(&message_bits, LamportType::SHA256, idx)?;
+
+                assert!(
+                    lamport.verify_signature(&message_bits, &signature, &keys[idx as usize])?,
+                    "Key at index {} should work correctly",
+                    idx
                 );
             }
 

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -8101,13 +8101,22 @@ mod tests {
         let message_bit_length = 10;
 
         // Create a 10-bit message: [1, 0, 1, 0, 1, 0, 1, 0, 1, 0]
-        let message_bits: Vec<bool> = vec![true, false, true, false, true, false, true, false, true, false];
+        let message_bits: Vec<bool> = vec![
+            true, false, true, false, true, false, true, false, true, false,
+        ];
 
         // Convert to bytes using Lamport's bits_to_bytes function (adds padding)
         // 10 bits requires 6 padding bits to reach 16 bits (2 bytes)
         let (message_bytes, padding) = crate::lamport::bits_to_bytes(&message_bits)?;
-        assert_eq!(padding, 6, "10 bits should require 6 bits of padding to reach 16 bits");
-        assert_eq!(message_bytes.len(), 2, "10 bits + 6 padding = 16 bits = 2 bytes");
+        assert_eq!(
+            padding, 6,
+            "10 bits should require 6 bits of padding to reach 16 bits"
+        );
+        assert_eq!(
+            message_bytes.len(),
+            2,
+            "10 bits + 6 padding = 16 bits = 2 bytes"
+        );
 
         // Use a fixed mnemonic for reproducibility
         let test_mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
@@ -8142,7 +8151,8 @@ mod tests {
         let key_manager2 = create_key_manager_from_config(&key_manager_config, keystore2, store2)?;
 
         // Derive the same key (index 0, 10-bit message) - not marked as used in this storage
-        let public_key2 = key_manager2.derive_lamport(message_bit_length, LamportType::SHA256, 0)?;
+        let public_key2 =
+            key_manager2.derive_lamport(message_bit_length, LamportType::SHA256, 0)?;
 
         // Verify we got the same public key
         assert_eq!(
@@ -8162,7 +8172,8 @@ mod tests {
         //
         // The byte-based method (sign_lamport_message_bytes_by_pubkey) is ONLY for:
         // - Message lengths that are exact multiples of 8 bits (e.g., 8, 16, 24, 32, 256 bits)
-        let result = key_manager2.sign_lamport_message_bytes_by_pubkey(&message_bytes, &public_key2);
+        let result =
+            key_manager2.sign_lamport_message_bytes_by_pubkey(&message_bytes, &public_key2);
 
         // Assert that we get the expected MessageLengthMismatch error
         assert!(
@@ -8172,7 +8183,7 @@ mod tests {
 
         match result {
             Err(KeyManagerError::LamportGenerationError(
-                crate::errors::LamportError::MessageLengthMismatch(got, expected)
+                crate::errors::LamportError::MessageLengthMismatch(got, expected),
             )) => {
                 assert_eq!(got, 16, "Got 16 bits from 2 bytes");
                 assert_eq!(expected, 10, "Expected 10 bits from key configuration");

--- a/src/key_store.rs
+++ b/src/key_store.rs
@@ -24,6 +24,7 @@ impl KeyStore {
                                                                        // TODO adjust block size to optimize storage, according to the estimation of max winternitz keys needed
     const WOTS_CHECK_BLOCK_SIZE: u64 = 1024; // Number of indices per bitmap block
     const WOTS_CHECK_BLOCK_BYTES: usize = (Self::WOTS_CHECK_BLOCK_SIZE / 8) as usize; // 128 bytes per block
+    const LAMPORT: &str = "lamport"; // Key prefix for Lamport pubkeys
 
     pub fn new(store: Rc<Storage>) -> Self {
         Self { store }
@@ -295,6 +296,66 @@ impl KeyStore {
         if let Some(privk) = privk {
             let rsa_keypair = RSAKeyPair::from_private_pem(&privk)?;
             return Ok(Some(rsa_keypair));
+        }
+
+        Ok(None)
+    }
+
+    fn format_lamport_key(key_0s: &[[u8; 32]], key_1s: &[[u8; 32]]) -> String {
+    // TODO optimize storage format? hash the concatenation?
+        format!(
+            "{}:{}:{}",
+            Self::LAMPORT,
+            general_purpose::STANDARD.encode(key_0s.concat()),
+            general_purpose::STANDARD.encode(key_1s.concat())
+        )
+    }
+
+    pub fn store_lamport_key_sha256(&self, private_key_0s: Zeroizing<Vec<[u8; 32]>>, private_key_1s: Zeroizing<Vec<[u8; 32]>>, public_key_0s: Vec<[u8; 32]>, public_key_1s: Vec<[u8; 32]>) -> Result<(), KeyManagerError> {
+        // TODO discuss, winternitz key design decision was not to be stored, but lamport?
+        let pubk = Zeroizing::new(Self::format_lamport_key(&public_key_0s, &public_key_1s));
+        let privk = Zeroizing::new(Self::format_lamport_key(&private_key_0s, &private_key_1s));
+        self.store.set(pubk, &(*privk), None)?;
+        Ok(())
+    }
+
+    pub fn load_lamport_key_sha256(&self, public_key_0s: Vec<[u8; 32]>, public_key_1s: Vec<[u8; 32]>) -> Result<Option<(Zeroizing<Vec<[u8; 32]>>, Zeroizing<Vec<[u8; 32]>>)>, KeyManagerError> {
+        // TODO test store and load
+        let pubk = Self::format_lamport_key(&public_key_0s, &public_key_1s);
+        let privk: Option<Zeroizing<String>> =
+            self.store.get::<String, String>(pubk)?.map(Zeroizing::new);
+
+        if let Some(privk) = privk {
+            let parts: Vec<&str> = privk.split(':').collect();
+            if parts.len() != 3 || parts[0] != Self::LAMPORT {
+                return Err(KeyManagerError::InvalidLamportPrivateKey);
+            }
+            let private_key_0s_decoded = general_purpose::STANDARD.decode(parts[1].as_bytes()).map_err(|_| KeyManagerError::InvalidLamportPrivateKey)?;
+            let private_key_1s_decoded = general_purpose::STANDARD.decode(parts[2].as_bytes()).map_err(|_| KeyManagerError::InvalidLamportPrivateKey)?;
+
+            if private_key_0s_decoded.len() % 32 != 0 || private_key_1s_decoded.len() % 32 != 0 {
+                return Err(KeyManagerError::InvalidLamportPrivateKey);
+            }
+
+            let private_key_0s = Zeroizing::new(private_key_0s_decoded
+                .chunks(32)
+                .map(|chunk| {
+                    let mut arr = [0u8; 32];
+                    arr.copy_from_slice(chunk);
+                    arr
+                })
+                .collect());
+
+            let private_key_1s = Zeroizing::new(private_key_1s_decoded
+                .chunks(32)
+                .map(|chunk| {
+                    let mut arr = [0u8; 32];
+                    arr.copy_from_slice(chunk);
+                    arr
+                })
+                .collect());
+
+            return Ok(Some((private_key_0s, private_key_1s)));
         }
 
         Ok(None)

--- a/src/key_store.rs
+++ b/src/key_store.rs
@@ -36,7 +36,7 @@ impl KeyStore {
     const NEXT_LAMPORT_INDEX_KEY: &str = "next_lamport_index"; // Key for storing the next lamport index
     const WINTERNITZ_INDEX_BLOCK_KEY: &str = "winternitz_index_block"; // Key prefix for Winternitz index bitmap blocks
     const LAMPORT_INDEX_BLOCK_KEY: &str = "lamport_index_block"; // Key prefix for Lamport index bitmap blocks
-    // TODO adjust block size to optimize storage, according to the estimation of max winternitz keys needed
+                                                                 // TODO adjust block size to optimize storage, according to the estimation of max winternitz keys needed
     const WOTS_CHECK_BLOCK_SIZE: u64 = 1024; // Number of indices per bitmap block
     const WOTS_CHECK_BLOCK_BYTES: usize = (Self::WOTS_CHECK_BLOCK_SIZE / 8) as usize; // 128 bytes per block
     const LAMPORT_CHECK_BLOCK_SIZE: u64 = 1024; // Number of indices per bitmap block
@@ -395,7 +395,8 @@ impl KeyStore {
             }
 
             let key_bytes_part = parts[1];
-            let spent = parts[2].parse::<bool>()
+            let spent = parts[2]
+                .parse::<bool>()
                 .map_err(|_| KeyManagerError::InvalidLamportPrivateKey)?;
 
             let private_key_decoded = general_purpose::STANDARD
@@ -426,7 +427,6 @@ impl KeyStore {
         index: u32,
         transaction_id: Option<Uuid>,
     ) -> Result<(), KeyManagerError> {
-
         // Bitmap with block size of 1024 indices for efficiency
         // Each block represents 1024 indices and uses 128 bytes (1024 bits / 8)
 
@@ -468,7 +468,6 @@ impl KeyStore {
         public_key: &LamportPublicKey,
         transaction_id: Option<Uuid>,
     ) -> Result<(), KeyManagerError> {
-
         // Check if the public key is marked as imported
         if !public_key.imported() {
             return Err(KeyManagerError::LamportKeyNotMarkedAsImported);

--- a/src/key_store.rs
+++ b/src/key_store.rs
@@ -1,4 +1,9 @@
-use crate::{errors::KeyManagerError, key_type::BitcoinKeyType, lamport::{LamportPrivateKey, LamportPublicKey}, rsa::RSAKeyPair};
+use crate::{
+    errors::KeyManagerError,
+    key_type::BitcoinKeyType,
+    lamport::{LamportPrivateKey, LamportPublicKey},
+    rsa::RSAKeyPair,
+};
 use base64::{engine::general_purpose, Engine as _};
 use bip39::Mnemonic;
 use bitcoin::{PrivateKey, PublicKey};
@@ -302,8 +307,8 @@ impl KeyStore {
     }
 
     fn format_lamport_storage_key(public_key: &LamportPublicKey) -> String {
-    // TODO optimize storage format? hash the concatenation?
-    // TODO check if there is already e fun in the lamport object to do this formatting, to avoid code duplication and potential inconsistencies
+        // TODO optimize storage format? hash the concatenation?
+        // TODO check if there is already e fun in the lamport object to do this formatting, to avoid code duplication and potential inconsistencies
         format!(
             "{}:{}",
             Self::LAMPORT,
@@ -319,14 +324,21 @@ impl KeyStore {
         )
     }
 
-    pub fn store_lamport_key(&self, private_key: &LamportPrivateKey, public_key: &LamportPublicKey) -> Result<(), KeyManagerError> {
+    pub fn store_lamport_key(
+        &self,
+        private_key: &LamportPrivateKey,
+        public_key: &LamportPublicKey,
+    ) -> Result<(), KeyManagerError> {
         let pubk = Self::format_lamport_storage_key(public_key);
         let privk = Zeroizing::new(Self::format_lamport_storage_value(private_key));
         self.store.set(pubk, &(*privk), None)?;
         Ok(())
     }
 
-    pub fn load_lamport_key(&self, public_key: &LamportPublicKey) -> Result<Option<LamportPrivateKey>, KeyManagerError> {
+    pub fn load_lamport_key(
+        &self,
+        public_key: &LamportPublicKey,
+    ) -> Result<Option<LamportPrivateKey>, KeyManagerError> {
         // TODO test store and load
         // TODO if we need splited 0s and 1s, format storake key and value, using to_bytes_splitted instead
         let pubk = Self::format_lamport_storage_key(public_key);
@@ -338,8 +350,15 @@ impl KeyStore {
             if parts.len() != 3 || parts[0] != Self::LAMPORT {
                 return Err(KeyManagerError::InvalidLamportPrivateKey);
             }
-            let private_key_decoded = general_purpose::STANDARD.decode(parts[1].as_bytes()).map_err(|_| KeyManagerError::InvalidLamportPrivateKey)?;
-            let private_key = LamportPrivateKey::from_bytes(&private_key_decoded, public_key.message_bit_length()?, public_key.hash_type(), 0)?;
+            let private_key_decoded = general_purpose::STANDARD
+                .decode(parts[1].as_bytes())
+                .map_err(|_| KeyManagerError::InvalidLamportPrivateKey)?;
+            let private_key = LamportPrivateKey::from_bytes(
+                &private_key_decoded,
+                public_key.message_bit_length()?,
+                public_key.hash_type(),
+                0,
+            )?;
             // TODO is ok using 0 derivation index for stored (imported) lamport keys?
 
             return Ok(Some(private_key));

--- a/src/key_store.rs
+++ b/src/key_store.rs
@@ -17,6 +17,13 @@ pub struct KeyStore {
     store: Rc<Storage>,
 }
 
+/* TODO, Possible optimization:
+saving byte arrays instead of base64 general_purpose::STANDARD.encode/decode will reduce database size and improve performance,
+but it would require changing the Storage trait to support byte arrays,
+and also adjusting the serialization/deserialization logic accordingly.
+This could be a future improvement to consider after evaluating the current implementation's performance and storage efficiency.
+*/
+
 impl KeyStore {
     const MNEMONIC_KEY: &str = "bip39_mnemonic"; // Key for the BIP-39 mnemonic
     const MNEMONIC_PASSPHRASE_KEY: &str = "bip39_mnemonic_passphrase"; // Key for the BIP-39 mnemonic passphrase
@@ -307,13 +314,10 @@ impl KeyStore {
     }
 
     fn format_lamport_storage_key(public_key: &LamportPublicKey) -> String {
-        // TODO optimize storage format? hash the concatenation?
-        // TODO check if there is already e fun in the lamport object to do this formatting, to avoid code duplication and potential inconsistencies
-        format!(
-            "{}:{}",
-            Self::LAMPORT,
-            general_purpose::STANDARD.encode(public_key.to_bytes()), // TODO this could be long... save the has instead? research a bit.. if its not duplicating what rocksdb already does
-        )
+        // blake3 justification: This lamport key could be large to use it as storage key, impacting into rocksdb performance
+        let pubkey_bytes = public_key.to_bytes();
+        let hash = blake3::hash(&pubkey_bytes);
+        format!("{}:{}", Self::LAMPORT, hash.to_hex())
     }
 
     fn format_lamport_storage_value(private_key: &LamportPrivateKey) -> String {
@@ -340,7 +344,6 @@ impl KeyStore {
         public_key: &LamportPublicKey,
     ) -> Result<Option<LamportPrivateKey>, KeyManagerError> {
         // TODO test store and load
-        // TODO if we need splited 0s and 1s, format storake key and value, using to_bytes_splitted instead
         let pubk = Self::format_lamport_storage_key(public_key);
         let privk: Option<Zeroizing<String>> =
             self.store.get::<String, String>(pubk)?.map(Zeroizing::new);
@@ -359,7 +362,7 @@ impl KeyStore {
                 public_key.hash_type(),
                 0,
             )?;
-            // TODO is ok using 0 derivation index for stored (imported) lamport keys?
+            // TODO use some mark for stored (imported) lamport keys
 
             return Ok(Some(private_key));
         }

--- a/src/key_store.rs
+++ b/src/key_store.rs
@@ -406,6 +406,7 @@ impl KeyStore {
                 public_key.message_bit_length()?,
                 public_key.hash_type(),
                 None,
+                true, // imported: true for imported keys
             )?;
 
             // Set the spent flag

--- a/src/key_store.rs
+++ b/src/key_store.rs
@@ -426,8 +426,6 @@ impl KeyStore {
         transaction_id: Option<Uuid>,
     ) -> Result<(), KeyManagerError> {
 
-        // TODO - if prublic_key has imported in true, -> error, key marked as imported, here it must be derivated
-
         // Bitmap with block size of 1024 indices for efficiency
         // Each block represents 1024 indices and uses 128 bytes (1024 bits / 8)
 

--- a/src/key_store.rs
+++ b/src/key_store.rs
@@ -1,4 +1,4 @@
-use crate::{errors::KeyManagerError, key_type::BitcoinKeyType, rsa::RSAKeyPair};
+use crate::{errors::KeyManagerError, key_type::BitcoinKeyType, lamport::{LamportPrivateKey, LamportPublicKey}, rsa::RSAKeyPair};
 use base64::{engine::general_purpose, Engine as _};
 use bip39::Mnemonic;
 use bitcoin::{PrivateKey, PublicKey};
@@ -301,27 +301,35 @@ impl KeyStore {
         Ok(None)
     }
 
-    fn format_lamport_key(key_0s: &[[u8; 32]], key_1s: &[[u8; 32]]) -> String {
+    fn format_lamport_storage_key(public_key: &LamportPublicKey) -> String {
     // TODO optimize storage format? hash the concatenation?
+    // TODO check if there is already e fun in the lamport object to do this formatting, to avoid code duplication and potential inconsistencies
         format!(
-            "{}:{}:{}",
+            "{}:{}",
             Self::LAMPORT,
-            general_purpose::STANDARD.encode(key_0s.concat()),
-            general_purpose::STANDARD.encode(key_1s.concat())
+            general_purpose::STANDARD.encode(public_key.to_bytes()), // TODO this could be long... save the has instead? research a bit.. if its not duplicating what rocksdb already does
         )
     }
 
-    pub fn store_lamport_key_sha256(&self, private_key_0s: Zeroizing<Vec<[u8; 32]>>, private_key_1s: Zeroizing<Vec<[u8; 32]>>, public_key_0s: Vec<[u8; 32]>, public_key_1s: Vec<[u8; 32]>) -> Result<(), KeyManagerError> {
-        // TODO discuss, winternitz key design decision was not to be stored, but lamport?
-        let pubk = Zeroizing::new(Self::format_lamport_key(&public_key_0s, &public_key_1s));
-        let privk = Zeroizing::new(Self::format_lamport_key(&private_key_0s, &private_key_1s));
+    fn format_lamport_storage_value(private_key: &LamportPrivateKey) -> String {
+        format!(
+            "{}:{}",
+            Self::LAMPORT,
+            general_purpose::STANDARD.encode(private_key.to_bytes()),
+        )
+    }
+
+    pub fn store_lamport_key(&self, private_key: &LamportPrivateKey, public_key: &LamportPublicKey) -> Result<(), KeyManagerError> {
+        let pubk = Self::format_lamport_storage_key(public_key);
+        let privk = Zeroizing::new(Self::format_lamport_storage_value(private_key));
         self.store.set(pubk, &(*privk), None)?;
         Ok(())
     }
 
-    pub fn load_lamport_key_sha256(&self, public_key_0s: Vec<[u8; 32]>, public_key_1s: Vec<[u8; 32]>) -> Result<Option<(Zeroizing<Vec<[u8; 32]>>, Zeroizing<Vec<[u8; 32]>>)>, KeyManagerError> {
+    pub fn load_lamport_key(&self, public_key: &LamportPublicKey) -> Result<Option<LamportPrivateKey>, KeyManagerError> {
         // TODO test store and load
-        let pubk = Self::format_lamport_key(&public_key_0s, &public_key_1s);
+        // TODO if we need splited 0s and 1s, format storake key and value, using to_bytes_splitted instead
+        let pubk = Self::format_lamport_storage_key(public_key);
         let privk: Option<Zeroizing<String>> =
             self.store.get::<String, String>(pubk)?.map(Zeroizing::new);
 
@@ -330,32 +338,11 @@ impl KeyStore {
             if parts.len() != 3 || parts[0] != Self::LAMPORT {
                 return Err(KeyManagerError::InvalidLamportPrivateKey);
             }
-            let private_key_0s_decoded = general_purpose::STANDARD.decode(parts[1].as_bytes()).map_err(|_| KeyManagerError::InvalidLamportPrivateKey)?;
-            let private_key_1s_decoded = general_purpose::STANDARD.decode(parts[2].as_bytes()).map_err(|_| KeyManagerError::InvalidLamportPrivateKey)?;
+            let private_key_decoded = general_purpose::STANDARD.decode(parts[1].as_bytes()).map_err(|_| KeyManagerError::InvalidLamportPrivateKey)?;
+            let private_key = LamportPrivateKey::from_bytes(&private_key_decoded, public_key.message_bit_length()?, public_key.hash_type(), 0)?;
+            // TODO is ok using 0 derivation index for stored (imported) lamport keys?
 
-            if private_key_0s_decoded.len() % 32 != 0 || private_key_1s_decoded.len() % 32 != 0 {
-                return Err(KeyManagerError::InvalidLamportPrivateKey);
-            }
-
-            let private_key_0s = Zeroizing::new(private_key_0s_decoded
-                .chunks(32)
-                .map(|chunk| {
-                    let mut arr = [0u8; 32];
-                    arr.copy_from_slice(chunk);
-                    arr
-                })
-                .collect());
-
-            let private_key_1s = Zeroizing::new(private_key_1s_decoded
-                .chunks(32)
-                .map(|chunk| {
-                    let mut arr = [0u8; 32];
-                    arr.copy_from_slice(chunk);
-                    arr
-                })
-                .collect());
-
-            return Ok(Some((private_key_0s, private_key_1s)));
+            return Ok(Some(private_key));
         }
 
         Ok(None)

--- a/src/key_store.rs
+++ b/src/key_store.rs
@@ -17,7 +17,7 @@ pub struct KeyStore {
     store: Rc<Storage>,
 }
 
-/* TODO, Possible optimization:
+/* Dev Note: Possible optimization:
 saving byte arrays instead of base64 general_purpose::STANDARD.encode/decode will reduce database size and improve performance,
 but it would require changing the Storage trait to support byte arrays,
 and also adjusting the serialization/deserialization logic accordingly.
@@ -358,13 +358,15 @@ impl KeyStore {
 
     fn format_lamport_storage_value(private_key: &LamportPrivateKey) -> String {
         format!(
-            "{}:{}",
+            "{}:{}:{}",
             Self::LAMPORT,
             general_purpose::STANDARD.encode(private_key.to_bytes()),
+            private_key.spent(),
         )
     }
 
-    pub fn store_lamport_key(
+    // we are not storing derived keys
+    pub fn store_lamport_imported_key(
         &self,
         private_key: &LamportPrivateKey,
         public_key: &LamportPublicKey,
@@ -375,7 +377,8 @@ impl KeyStore {
         Ok(())
     }
 
-    pub fn load_lamport_key(
+    // we are not storing derived keys
+    pub fn load_lamport_imported_key(
         &self,
         public_key: &LamportPublicKey,
     ) -> Result<Option<LamportPrivateKey>, KeyManagerError> {
@@ -385,19 +388,30 @@ impl KeyStore {
 
         if let Some(privk) = privk {
             let parts: Vec<&str> = privk.split(':').collect();
-            if parts.len() != 2 || parts[0] != Self::LAMPORT {
+
+            // Expected format: lamport:base64_key:spent
+            if parts.len() != 3 || parts[0] != Self::LAMPORT {
                 return Err(KeyManagerError::InvalidLamportPrivateKey);
             }
-            let private_key_decoded = general_purpose::STANDARD
-                .decode(parts[1].as_bytes())
+
+            let key_bytes_part = parts[1];
+            let spent = parts[2].parse::<bool>()
                 .map_err(|_| KeyManagerError::InvalidLamportPrivateKey)?;
-            let private_key = LamportPrivateKey::from_bytes(
+
+            let private_key_decoded = general_purpose::STANDARD
+                .decode(key_bytes_part.as_bytes())
+                .map_err(|_| KeyManagerError::InvalidLamportPrivateKey)?;
+            let mut private_key = LamportPrivateKey::from_bytes(
                 &private_key_decoded,
                 public_key.message_bit_length()?,
                 public_key.hash_type(),
-                0,
+                None,
             )?;
-            // TODO use some mark for stored (imported) lamport keys
+
+            // Set the spent flag
+            if spent {
+                private_key.mark_spent();
+            }
 
             return Ok(Some(private_key));
         }
@@ -405,14 +419,15 @@ impl KeyStore {
         Ok(None)
     }
 
-
-    // TODO, ask if is derivated use this func, if it was imported marj in some other way
     // this index is independent of the index used for key derivation, it is marked when used in a signature
-    pub fn check_and_mark_lamport_index_used(
+    pub fn check_and_mark_lamport_index_used_derivated(
         &self,
         index: u32,
         transaction_id: Option<Uuid>,
     ) -> Result<(), KeyManagerError> {
+
+        // TODO - if prublic_key has imported in true, -> error, key marked as imported, here it must be derivated
+
         // Bitmap with block size of 1024 indices for efficiency
         // Each block represents 1024 indices and uses 128 bytes (1024 bits / 8)
 
@@ -445,6 +460,42 @@ impl KeyStore {
 
         // Store the updated block back to storage
         self.store.set(block_key, block, transaction_id)?;
+
+        Ok(())
+    }
+
+    pub fn check_and_mark_lamport_used_imported(
+        &self,
+        public_key: &LamportPublicKey,
+        transaction_id: Option<Uuid>,
+    ) -> Result<(), KeyManagerError> {
+
+        // Check if the public key is marked as imported
+        if !public_key.imported() {
+            return Err(KeyManagerError::LamportKeyNotMarkedAsImported);
+        }
+
+        // Load the key from storage
+        let optional_private_key = self.load_lamport_imported_key(public_key)?;
+
+        // Check if the key exists
+        let mut private_key = match optional_private_key {
+            Some(key) => key,
+            None => return Err(KeyManagerError::LamportPrivateKeyNotFound),
+        };
+
+        // Check if the key was already used to sign (spent)
+        if private_key.spent() {
+            return Err(KeyManagerError::LamportImportedKeyAlreadyUsed);
+        }
+
+        // Mark the key as spent
+        private_key.mark_spent();
+
+        // Store the updated key
+        let pubk = Self::format_lamport_storage_key(public_key);
+        let privk = Zeroizing::new(Self::format_lamport_storage_value(&private_key));
+        self.store.set(pubk, &(*privk), transaction_id)?;
 
         Ok(())
     }

--- a/src/key_store.rs
+++ b/src/key_store.rs
@@ -28,14 +28,19 @@ impl KeyStore {
     const MNEMONIC_KEY: &str = "bip39_mnemonic"; // Key for the BIP-39 mnemonic
     const MNEMONIC_PASSPHRASE_KEY: &str = "bip39_mnemonic_passphrase"; // Key for the BIP-39 mnemonic passphrase
     const WINTERNITZ_KEY: &str = "winternitz_seed"; // Key to use in the database for the Winternitz seed
+    const LAMPORT_KEY: &str = "lamport_seed"; // Key to use in the database for the Lamport seed
     const KEY_DERIVATION_SEED_KEY: &str = "bip32_seed"; // Key to use in the database for the bip32 key derivation seed
     const UNKNOWN_TYPE: &str = "unknown"; // Key type string for unknown/unspecified key types
     const NEXT_KEYPAIR_INDEX_KEY: &str = "next_keypair_index"; // Key for storing the next keypair index
     const NEXT_WINTERNITZ_INDEX_KEY: &str = "next_winternitz_index"; // Key for storing the next winternitz index
+    const NEXT_LAMPORT_INDEX_KEY: &str = "next_lamport_index"; // Key for storing the next lamport index
     const WINTERNITZ_INDEX_BLOCK_KEY: &str = "winternitz_index_block"; // Key prefix for Winternitz index bitmap blocks
-                                                                       // TODO adjust block size to optimize storage, according to the estimation of max winternitz keys needed
+    const LAMPORT_INDEX_BLOCK_KEY: &str = "lamport_index_block"; // Key prefix for Lamport index bitmap blocks
+    // TODO adjust block size to optimize storage, according to the estimation of max winternitz keys needed
     const WOTS_CHECK_BLOCK_SIZE: u64 = 1024; // Number of indices per bitmap block
     const WOTS_CHECK_BLOCK_BYTES: usize = (Self::WOTS_CHECK_BLOCK_SIZE / 8) as usize; // 128 bytes per block
+    const LAMPORT_CHECK_BLOCK_SIZE: u64 = 1024; // Number of indices per bitmap block
+    const LAMPORT_CHECK_BLOCK_BYTES: usize = (Self::LAMPORT_CHECK_BLOCK_SIZE / 8) as usize; // 128 bytes per block
     const LAMPORT: &str = "lamport"; // Key prefix for Lamport pubkeys
 
     pub fn new(store: Rc<Storage>) -> Self {
@@ -167,6 +172,25 @@ impl KeyStore {
         }
     }
 
+    pub fn store_next_lamport_index(
+        &self,
+        index: u32,
+        transaction_id: Option<Uuid>,
+    ) -> Result<(), KeyManagerError> {
+        // best practice: never reuse the index, as it can compromise security, even if the hash type changes
+        // this will store the next lamport index
+        self.store
+            .set(Self::NEXT_LAMPORT_INDEX_KEY, index, transaction_id)?;
+        Ok(())
+    }
+
+    pub fn load_next_lamport_index(&self) -> Result<u32, KeyManagerError> {
+        match self.store.get(Self::NEXT_LAMPORT_INDEX_KEY)? {
+            Some(next_index) => Ok(next_index),
+            None => Err(KeyManagerError::NextLamportIndexNotFound),
+        }
+    }
+
     pub fn store_mnemonic(&self, mnemonic: &Mnemonic) -> Result<(), KeyManagerError> {
         let phrase = Zeroizing::new(mnemonic.to_string()); // normalized space-separated phrase
         self.store.set(Self::MNEMONIC_KEY, &(*phrase), None)?;
@@ -204,6 +228,18 @@ impl KeyStore {
         match self.store.get(Self::WINTERNITZ_KEY)? {
             Some(entry) => Ok(Zeroizing::new(entry)),
             None => Err(KeyManagerError::WinternitzSeedNotFound),
+        }
+    }
+
+    pub fn store_lamport_seed(&self, seed: Zeroizing<[u8; 32]>) -> Result<(), KeyManagerError> {
+        self.store.set(Self::LAMPORT_KEY, *seed, None)?;
+        Ok(())
+    }
+
+    pub fn load_lamport_seed(&self) -> Result<Zeroizing<[u8; 32]>, KeyManagerError> {
+        match self.store.get(Self::LAMPORT_KEY)? {
+            Some(entry) => Ok(Zeroizing::new(entry)),
+            None => Err(KeyManagerError::LamportSeedNotFound),
         }
     }
 
@@ -367,5 +403,49 @@ impl KeyStore {
         }
 
         Ok(None)
+    }
+
+
+    // TODO, ask if is derivated use this func, if it was imported marj in some other way
+    // this index is independent of the index used for key derivation, it is marked when used in a signature
+    pub fn check_and_mark_lamport_index_used(
+        &self,
+        index: u32,
+        transaction_id: Option<Uuid>,
+    ) -> Result<(), KeyManagerError> {
+        // Bitmap with block size of 1024 indices for efficiency
+        // Each block represents 1024 indices and uses 128 bytes (1024 bits / 8)
+
+        let block_num = (index as u64) / Self::LAMPORT_CHECK_BLOCK_SIZE;
+        let bit_pos = (index as u64) % Self::LAMPORT_CHECK_BLOCK_SIZE;
+
+        let byte_index = (bit_pos / 8) as usize;
+        let bit_index = (bit_pos % 8) as u8;
+
+        // Load the block from storage (or create new if doesn't exist)
+        let block_key = format!("{}:{}", Self::LAMPORT_INDEX_BLOCK_KEY, block_num);
+        let mut block: Vec<u8> = match self.store.get::<String, Vec<u8>>(block_key.clone())? {
+            Some(block) => block,
+            None => vec![0u8; Self::LAMPORT_CHECK_BLOCK_BYTES], // Create new empty block
+        };
+
+        // Validate block size
+        if block.len() != Self::LAMPORT_CHECK_BLOCK_BYTES {
+            return Err(KeyManagerError::CorruptedLamportIndexBitmap);
+        }
+
+        // Check if the bit is already set (index already used)
+        let mask = 1u8 << bit_index;
+        if block[byte_index] & mask != 0 {
+            return Err(KeyManagerError::LamportIndexAlreadyUsed(index));
+        }
+
+        // Mark the bit as used
+        block[byte_index] |= mask;
+
+        // Store the updated block back to storage
+        self.store.set(block_key, block, transaction_id)?;
+
+        Ok(())
     }
 }

--- a/src/key_store.rs
+++ b/src/key_store.rs
@@ -343,14 +343,13 @@ impl KeyStore {
         &self,
         public_key: &LamportPublicKey,
     ) -> Result<Option<LamportPrivateKey>, KeyManagerError> {
-        // TODO test store and load
         let pubk = Self::format_lamport_storage_key(public_key);
         let privk: Option<Zeroizing<String>> =
             self.store.get::<String, String>(pubk)?.map(Zeroizing::new);
 
         if let Some(privk) = privk {
             let parts: Vec<&str> = privk.split(':').collect();
-            if parts.len() != 3 || parts[0] != Self::LAMPORT {
+            if parts.len() != 2 || parts[0] != Self::LAMPORT {
                 return Err(KeyManagerError::InvalidLamportPrivateKey);
             }
             let private_key_decoded = general_purpose::STANDARD

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -1,0 +1,972 @@
+use core::fmt;
+use std::str::FromStr;
+
+use bitcoin::hashes::{ripemd160, sha256, Hash, HashEngine, Hmac, HmacEngine};
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+// use zeroize::Zeroize;
+
+use crate::errors::LamportError;
+
+pub const SHA256_SIZE: usize = 32;
+pub const RIPEMD160_SIZE: usize = 20;
+
+/// Lamport signature hash function types
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]
+pub enum LamportType {
+    // Based on some bitcoin script hash functions, but can be extended in the future if needed
+    // If needed HASH256 (two times sha256) or RIPMED160 (without sha256) could be added here as well
+    SHA256,
+    HASH160,
+}
+
+pub trait HashFunction {
+    fn hash(&self, data: &[u8]) -> LamportHash;
+    fn hash_size(&self) -> usize;
+}
+
+impl HashFunction for LamportType {
+    fn hash(&self, data: &[u8]) -> LamportHash {
+        let hash = match self {
+            LamportType::SHA256 => {
+                LamportHash::new(sha256::Hash::hash(data).as_byte_array().to_vec())
+            }
+            LamportType::HASH160 => {
+                let sha256 = sha256::Hash::hash(data);
+                let hash160 = ripemd160::Hash::hash(sha256.as_byte_array());
+                LamportHash::new(hash160.as_byte_array().to_vec())
+            }
+        };
+        hash
+    }
+
+    fn hash_size(&self) -> usize {
+        match self {
+            LamportType::SHA256 => SHA256_SIZE,
+            LamportType::HASH160 => RIPEMD160_SIZE,
+        }
+    }
+}
+
+impl fmt::Display for LamportType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+impl FromStr for LamportType {
+    type Err = LamportError;
+
+    fn from_str(input: &str) -> Result<LamportType, Self::Err> {
+        match input.to_uppercase().as_str() {
+            "SHA256" => Ok(LamportType::SHA256),
+            "HASH160" => Ok(LamportType::HASH160),
+            _ => Err(LamportError::InvalidLamportType(input.to_string())),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LamportHash {
+    hash: Vec<u8>,
+}
+
+// TODO do we want zeroize private key on drop? or left responsibility to the caller?
+// impl Zeroize for LamportHash {
+//     fn zeroize(&mut self) {
+//         self.hash.zeroize();
+//     }
+// }
+
+impl LamportHash {
+    pub fn new(hash: Vec<u8>) -> Self {
+        LamportHash { hash }
+    }
+
+    pub fn len(&self) -> usize {
+        self.hash.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.hash.is_empty()
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.hash.clone()
+    }
+
+    pub fn to_array(&self) -> Result<[u8; 32], LamportError> {
+        if self.hash.len() != 32 {
+            return Err(LamportError::InvalidHashSize(self.hash.len(), 32));
+        }
+        let mut array = [0u8; 32];
+        array.copy_from_slice(&self.hash);
+        Ok(array)
+    }
+
+    pub fn to_hex(&self) -> String {
+        hex::encode(&self.hash)
+    }
+}
+
+/// Lamport signature containing the revealed private key fragments
+/// For each bit in the message:
+///   - If bit is 0, reveal private_key_0
+///   - If bit is 1, reveal private_key_1
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LamportSignature {
+    /// The revealed private key hashes (one per bit in the message)
+    revealed_keys: Vec<LamportHash>,
+    /// The bit length of the original message
+    message_bit_length: usize,
+    /// The hash type used
+    hash_type: LamportType,
+}
+
+impl LamportSignature {
+    pub fn new(message_bit_length: usize, hash_type: LamportType) -> Self {
+        LamportSignature {
+            revealed_keys: Vec::with_capacity(message_bit_length),
+            hash_type,
+            message_bit_length,
+        }
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        for hash in self.revealed_keys.iter() {
+            bytes.extend_from_slice(&hash.hash);
+        }
+        bytes
+    }
+
+    pub fn from_bytes(
+        bytes: &[u8],
+        message_bit_length: usize,
+        hash_type: LamportType,
+    ) -> Result<Self, LamportError> {
+        let hash_size = hash_type.hash_size();
+
+        if bytes.len() != message_bit_length * hash_size {
+            return Err(LamportError::InvalidSignatureLength(
+                bytes.len(),
+                message_bit_length * hash_size,
+            ));
+        }
+
+        let mut signature = LamportSignature::new(message_bit_length, hash_type);
+
+        for i in 0..message_bit_length {
+            let start = i * hash_size;
+            let end = start + hash_size;
+            let hash = LamportHash::new(bytes[start..end].to_vec());
+            signature.push_revealed_key(hash)?;
+        }
+
+        Ok(signature)
+    }
+
+    pub fn to_hashes(&self) -> Vec<Vec<u8>> {
+        self.revealed_keys
+            .iter()
+            .map(|hash| hash.to_bytes())
+            .collect()
+    }
+
+    pub fn to_array_hashes(&self) -> Result<Vec<[u8; 32]>, LamportError> {
+        self.revealed_keys
+            .iter()
+            .map(|hash| hash.to_array())
+            .collect()
+    }
+
+    pub fn len(&self) -> usize {
+        self.revealed_keys.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.revealed_keys.is_empty()
+    }
+
+    pub fn message_bit_length(&self) -> usize {
+        self.message_bit_length
+    }
+
+    pub fn hash_type(&self) -> LamportType {
+        self.hash_type
+    }
+
+    fn push_revealed_key(&mut self, hash: LamportHash) -> Result<(), LamportError> {
+        if hash.len() != self.hash_type.hash_size() {
+            return Err(LamportError::HashSizeMismatch(
+                hash.len(),
+                self.hash_type.hash_size(),
+            ));
+        }
+        self.revealed_keys.push(hash);
+        Ok(())
+    }
+
+    fn revealed_key_at(&self, index: usize) -> Result<&LamportHash, LamportError> {
+        self.revealed_keys
+            .get(index)
+            .ok_or(LamportError::IndexOutOfBounds(index, self.revealed_keys.len()))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExtraData {
+    message_bit_length: usize,
+    derivation_index: u32, // TODO what to use if the key was imported and not derived?
+}
+
+impl ExtraData {
+    pub fn new(message_bit_length: usize, derivation_index: u32) -> Self {
+        ExtraData {
+            message_bit_length,
+            derivation_index,
+        }
+    }
+
+    pub fn message_bit_length(&self) -> usize {
+        self.message_bit_length
+    }
+
+    pub fn derivation_index(&self) -> u32 {
+        self.derivation_index
+    }
+}
+
+/// Lamport public key containing two sets of hash values:
+/// - public_key_0s: hashes for when the corresponding bit is 0
+/// - public_key_1s: hashes for when the corresponding bit is 1
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LamportPublicKey {
+    public_key_0s: Vec<LamportHash>,
+    public_key_1s: Vec<LamportHash>,
+    hash_type: LamportType,
+    extra_data: Option<ExtraData>,
+}
+
+impl LamportPublicKey {
+    pub fn from(private_key: LamportPrivateKey) -> Result<Self, LamportError> {
+        private_key.public_key()
+    }
+
+    pub fn new(hash_type: LamportType, extra_data: Option<ExtraData>) -> Self {
+        LamportPublicKey {
+            public_key_0s: Vec::new(),
+            public_key_1s: Vec::new(),
+            hash_type,
+            extra_data,
+        }
+    }
+
+    fn push_key_pair(
+        &mut self,
+        hash_0: LamportHash,
+        hash_1: LamportHash,
+    ) -> Result<(), LamportError> {
+        if hash_0.len() != self.hash_type.hash_size() {
+            return Err(LamportError::HashSizeMismatch(
+                hash_0.len(),
+                self.hash_type.hash_size(),
+            ));
+        }
+        if hash_1.len() != self.hash_type.hash_size() {
+            return Err(LamportError::HashSizeMismatch(
+                hash_1.len(),
+                self.hash_type.hash_size(),
+            ));
+        }
+
+        self.public_key_0s.push(hash_0);
+        self.public_key_1s.push(hash_1);
+
+        Ok(())
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+
+        // Serialize 0s
+        for hash in self.public_key_0s.iter() {
+            bytes.extend_from_slice(&hash.hash);
+        }
+
+        // Serialize 1s
+        for hash in self.public_key_1s.iter() {
+            bytes.extend_from_slice(&hash.hash);
+        }
+
+        bytes
+    }
+
+    pub fn from_bytes(
+        bytes: &[u8],
+        message_bit_length: usize,
+        hash_type: LamportType,
+    ) -> Result<Self, LamportError> {
+        let hash_size = hash_type.hash_size();
+        let expected_length = 2 * message_bit_length * hash_size;
+
+        if bytes.len() != expected_length {
+            return Err(LamportError::InvalidPublicKeyLength(
+                bytes.len(),
+                expected_length,
+            ));
+        }
+
+        let mut public_key = LamportPublicKey::new(hash_type, None);
+
+        // Split bytes into 0s and 1s sections
+        let split_point = message_bit_length * hash_size;
+        let bytes_0s = &bytes[..split_point];
+        let bytes_1s = &bytes[split_point..];
+
+        for i in 0..message_bit_length {
+            let start = i * hash_size;
+            let end = start + hash_size;
+
+            let hash_0 = LamportHash::new(bytes_0s[start..end].to_vec());
+            let hash_1 = LamportHash::new(bytes_1s[start..end].to_vec());
+
+            public_key.push_key_pair(hash_0, hash_1)?;
+        }
+
+        Ok(public_key)
+    }
+
+    pub fn to_hashes(&self) -> (Vec<Vec<u8>>, Vec<Vec<u8>>) {
+        let hashes_0s = self
+            .public_key_0s
+            .iter()
+            .map(|hash| hash.to_bytes())
+            .collect();
+        let hashes_1s = self
+            .public_key_1s
+            .iter()
+            .map(|hash| hash.to_bytes())
+            .collect();
+        (hashes_0s, hashes_1s)
+    }
+
+    pub fn to_array_hashes(&self) -> Result<(Vec<[u8; 32]>, Vec<[u8; 32]>), LamportError> {
+        let hashes_0s: Result<Vec<[u8; 32]>, LamportError> =
+            self.public_key_0s.iter().map(|hash| hash.to_array()).collect();
+        let hashes_1s: Result<Vec<[u8; 32]>, LamportError> =
+            self.public_key_1s.iter().map(|hash| hash.to_array()).collect();
+        Ok((hashes_0s?, hashes_1s?))
+    }
+
+    pub fn to_hashes_string(&self) -> (Vec<String>, Vec<String>) {
+        let hashes_0s = self.public_key_0s.iter().map(|hash| hash.to_hex()).collect();
+        let hashes_1s = self.public_key_1s.iter().map(|hash| hash.to_hex()).collect();
+        (hashes_0s, hashes_1s)
+    }
+
+    /// Defined as quantity of key pairs
+    pub fn len(&self) -> usize {
+        self.public_key_0s.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.public_key_0s.is_empty()
+    }
+
+    pub fn hash_size(&self) -> usize {
+        self.hash_type.hash_size()
+    }
+
+    pub fn hash_type(&self) -> LamportType {
+        self.hash_type
+    }
+
+    pub fn extra_data(&self) -> Option<ExtraData> {
+        self.extra_data.clone()
+    }
+
+    pub fn message_bit_length(&self) -> Result<usize, LamportError> {
+        let message_bit_length = self
+            .extra_data
+            .as_ref()
+            .ok_or(LamportError::ExtraDataMissing(
+                "message_bit_length".to_string(),
+            ))?
+            .message_bit_length;
+
+        Ok(message_bit_length)
+    }
+
+    pub fn derivation_index(&self) -> Result<u32, LamportError> {
+        let derivation_index = self
+            .extra_data
+            .as_ref()
+            .ok_or(LamportError::ExtraDataMissing(
+                "derivation_index".to_string(),
+            ))?
+            .derivation_index;
+
+        Ok(derivation_index)
+    }
+
+    fn public_key_0_at(&self, index: usize) -> Result<&LamportHash, LamportError> {
+        self.public_key_0s
+            .get(index)
+            .ok_or(LamportError::IndexOutOfBounds(index, self.public_key_0s.len()))
+    }
+
+    fn public_key_1_at(&self, index: usize) -> Result<&LamportHash, LamportError> {
+        self.public_key_1s
+            .get(index)
+            .ok_or(LamportError::IndexOutOfBounds(index, self.public_key_1s.len()))
+    }
+}
+
+/// Lamport private key containing two sets of secret values:
+/// - private_key_0s: secrets for when the corresponding bit is 0
+/// - private_key_1s: secrets for when the corresponding bit is 1
+///
+/// CRITICAL: Lamport signatures are ONE-TIME USE ONLY.
+/// Revealing multiple signatures with the same key compromises security.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LamportPrivateKey {
+    private_key_0s: Vec<LamportHash>,
+    private_key_1s: Vec<LamportHash>,
+    hash_type: LamportType,
+    message_bit_length: usize,
+    derivation_index: u32, // TODO what to use if the key was imported and not derived?
+}
+
+// TODO create from bytes or import method?
+impl LamportPrivateKey {
+    pub fn new(
+        hash_type: LamportType,
+        message_bit_length: usize,
+        derivation_index: u32,
+    ) -> Self {
+        LamportPrivateKey {
+            private_key_0s: Vec::with_capacity(message_bit_length),
+            private_key_1s: Vec::with_capacity(message_bit_length),
+            hash_type,
+            message_bit_length,
+            derivation_index,
+        }
+    }
+
+    pub fn public_key(&self) -> Result<LamportPublicKey, LamportError> {
+        let mut public_key = LamportPublicKey::new(
+            self.hash_type,
+            Some(ExtraData::new(self.message_bit_length, self.derivation_index)),
+        );
+
+        for i in 0..self.private_key_0s.len() {
+            let pub_0 = self.hash_type.hash(&self.private_key_0s[i].to_bytes());
+            let pub_1 = self.hash_type.hash(&self.private_key_1s[i].to_bytes());
+            public_key.push_key_pair(pub_0, pub_1)?;
+        }
+
+        Ok(public_key)
+    }
+
+    pub fn to_bytes(&self) -> (Vec<u8>, Vec<u8>) {
+        let mut bytes_0s = Vec::new();
+        let mut bytes_1s = Vec::new();
+
+        for hash_0 in self.private_key_0s.iter() {
+            bytes_0s.extend_from_slice(&hash_0.hash);
+        }
+
+        for hash_1 in self.private_key_1s.iter() {
+            bytes_1s.extend_from_slice(&hash_1.hash);
+        }
+
+        (bytes_0s, bytes_1s)
+    }
+
+    pub fn to_hashes(&self) -> (Vec<Vec<u8>>, Vec<Vec<u8>>) {
+        let hashes_0s = self
+            .private_key_0s
+            .iter()
+            .map(|hash| hash.to_bytes())
+            .collect();
+        let hashes_1s = self
+            .private_key_1s
+            .iter()
+            .map(|hash| hash.to_bytes())
+            .collect();
+        (hashes_0s, hashes_1s)
+    }
+
+    pub fn to_array_hashes(&self) -> Result<(Vec<[u8; 32]>, Vec<[u8; 32]>), LamportError> {
+        let hashes_0s: Result<Vec<[u8; 32]>, LamportError> = self
+            .private_key_0s
+            .iter()
+            .map(|hash| hash.to_array())
+            .collect();
+        let hashes_1s: Result<Vec<[u8; 32]>, LamportError> = self
+            .private_key_1s
+            .iter()
+            .map(|hash| hash.to_array())
+            .collect();
+        Ok((hashes_0s?, hashes_1s?))
+    }
+
+    pub fn len(&self) -> usize {
+        self.private_key_0s.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.private_key_0s.is_empty()
+    }
+
+    pub fn hash_size(&self) -> usize {
+        self.hash_type.hash_size()
+    }
+
+    pub fn hash_type(&self) -> LamportType {
+        self.hash_type
+    }
+
+    pub fn derivation_index(&self) -> u32 {
+        self.derivation_index
+    }
+
+    pub fn message_bit_length(&self) -> usize {
+        self.message_bit_length
+    }
+
+    fn push_key_pair(
+        &mut self,
+        hash_0: LamportHash,
+        hash_1: LamportHash,
+    ) -> Result<(), LamportError> {
+        if hash_0.len() != self.hash_type.hash_size() {
+            return Err(LamportError::HashSizeMismatch(
+                hash_0.len(),
+                self.hash_type.hash_size(),
+            ));
+        }
+        if hash_1.len() != self.hash_type.hash_size() {
+            return Err(LamportError::HashSizeMismatch(
+                hash_1.len(),
+                self.hash_type.hash_size(),
+            ));
+        }
+
+        self.private_key_0s.push(hash_0);
+        self.private_key_1s.push(hash_1);
+
+        Ok(())
+    }
+
+    fn private_key_0_at(&self, index: usize) -> Result<&LamportHash, LamportError> {
+        self.private_key_0s
+            .get(index)
+            .ok_or(LamportError::IndexOutOfBounds(index, self.private_key_0s.len()))
+    }
+
+    fn private_key_1_at(&self, index: usize) -> Result<&LamportHash, LamportError> {
+        self.private_key_1s
+            .get(index)
+            .ok_or(LamportError::IndexOutOfBounds(index, self.private_key_1s.len()))
+    }
+}
+
+// TODO do we want zeroize private key on drop? or left responsibility to the caller?
+// impl Drop for LamportPrivateKey {
+//     fn drop(&mut self) {
+//         // Zeroize the private keys on drop
+//         for hash in self.private_key_0s.iter_mut() {
+//             hash.hash.zeroize();
+//         }
+//         for hash in self.private_key_1s.iter_mut() {
+//             hash.hash.zeroize();
+//         }
+//     }
+// }
+
+/// Main Lamport signature scheme implementation
+#[derive(Default)]
+pub struct Lamport {}
+
+impl Lamport {
+    pub fn new() -> Self {
+        Lamport {}
+    }
+
+    // TODO what deriv index to use if the key was imported and not derived?
+    /// Generate a Lamport public key from a master secret
+    ///
+    /// # Arguments
+    /// * `master_secret` - The master secret seed for key derivation
+    /// * `hash_type` - The hash function to use (e.g., SHA256)
+    /// * `message_bit_length` - The length of messages that can be signed (in bits)
+    /// * `derivation_index` - The derivation index for this key (for HD derivation)
+    ///
+    /// # Returns
+    /// The generated public key
+    pub fn generate_public_key(
+        &self,
+        master_secret: &[u8],
+        hash_type: LamportType,
+        message_bit_length: usize,
+        derivation_index: u32,
+    ) -> Result<LamportPublicKey, LamportError> {
+        let private_key =
+            self.generate_private_key(master_secret, hash_type, message_bit_length, derivation_index)?;
+        let public_key = LamportPublicKey::from(private_key)?;
+        Ok(public_key)
+    }
+
+    // TODO what deriv index to use if the key was imported and not derived?
+    // TODO do we know if it was already used when importing?
+    /// Generate a Lamport private key from a master secret
+    ///
+    /// # Arguments
+    /// * `master_secret` - The master secret seed for key derivation
+    /// * `hash_type` - The hash function to use (e.g., SHA256)
+    /// * `message_bit_length` - The length of messages that can be signed (in bits)
+    /// * `derivation_index` - The derivation index for this key (for HD derivation)
+    ///
+    /// # Returns
+    /// The generated private key
+    ///
+    /// # Security Note
+    /// Store this key securely and mark it as used after signing to prevent reuse.
+    pub fn generate_private_key(
+        &self,
+        master_secret: &[u8],
+        hash_type: LamportType,
+        message_bit_length: usize,
+        derivation_index: u32,
+    ) -> Result<LamportPrivateKey, LamportError> {
+        derivation_index
+            .checked_add(1)
+            .ok_or(LamportError::IndexOverflow)?;
+
+        let mut private_key =
+            LamportPrivateKey::new(hash_type, message_bit_length, derivation_index);
+
+        let hash_size = hash_type.hash_size();
+
+        // Generate key pairs for each bit position
+        for i in 0..message_bit_length {
+            // Generate private key for bit value 0
+            let priv_key_0 = self.generate_hash(master_secret, hash_size, derivation_index, i as u32, 0);
+
+            // Generate private key for bit value 1
+            let priv_key_1 = self.generate_hash(master_secret, hash_size, derivation_index, i as u32, 1);
+
+            private_key.push_key_pair(priv_key_0, priv_key_1)?;
+        }
+
+        Ok(private_key)
+    }
+
+
+    // TODO Sing and Verify by message bits, and also by messages bytes, as for many cases using SHA256 as hash function will imply that the message is really the message digest, obtained by hashing also the message, so it willl be 32 exact bytes
+
+    /// Sign a message using a Lamport private key
+    ///
+    /// # Arguments
+    /// * `message_bits` - The message to sign as a vector of bits (0s and 1s)
+    /// * `private_key` - The private key to use for signing
+    ///
+    /// # Returns
+    /// The signature containing the revealed private key fragments
+    ///
+    /// # Security Critical
+    /// After calling this function, the private key MUST be marked as used and never reused.
+    /// Reusing a Lamport private key allows attackers to forge signatures.
+    pub fn sign_message(
+        &self,
+        message_bits: &[u8], // TODO i prefer to be an array of booleans, as a bit is only 0 or 1
+        private_key: &LamportPrivateKey,
+    ) -> Result<LamportSignature, LamportError> {
+        if message_bits.len() != private_key.message_bit_length() {
+            return Err(LamportError::MessageLengthMismatch(
+                message_bits.len(),
+                private_key.message_bit_length(),
+            ));
+        }
+
+        let mut signature = LamportSignature::new(message_bits.len(), private_key.hash_type());
+
+        // For each bit, reveal the corresponding private key
+        for (i, &bit) in message_bits.iter().enumerate() {
+            let revealed_key = if bit == 1 {
+                private_key.private_key_1_at(i)?.clone()
+            } else if bit == 0 {
+                private_key.private_key_0_at(i)?.clone()
+            } else {
+                return Err(LamportError::InvalidBitValue(bit));
+            };
+
+            signature.push_revealed_key(revealed_key)?;
+        }
+
+        Ok(signature)
+    }
+
+    /// Verify a Lamport signature
+    ///
+    /// # Arguments
+    /// * `message_bits` - The message that was allegedly signed (as bits)
+    /// * `signature` - The signature to verify
+    /// * `public_key` - The public key to verify against
+    ///
+    /// # Returns
+    /// True if the signature is valid, false otherwise
+    pub fn verify_signature(
+        &self,
+        message_bits: &[u8], // TODO i prefer to be an array of booleans, as a bit is only 0 or 1
+        signature: &LamportSignature,
+        public_key: &LamportPublicKey,
+    ) -> Result<bool, LamportError> {
+        if message_bits.len() != signature.message_bit_length() {
+            return Err(LamportError::MessageLengthMismatch(
+                message_bits.len(),
+                signature.message_bit_length(),
+            ));
+        }
+
+        if message_bits.len() != public_key.len() {
+            return Err(LamportError::MessageLengthMismatch(
+                message_bits.len(),
+                public_key.len(),
+            ));
+        }
+
+        let hash_type = public_key.hash_type();
+
+        // For each bit, verify the revealed key hashes to the correct public key
+        for (i, &bit) in message_bits.iter().enumerate() {
+            let revealed_key = signature.revealed_key_at(i)?;
+            let hash_of_revealed = hash_type.hash(&revealed_key.to_bytes());
+
+            let expected_public_key = if bit == 1 {
+                public_key.public_key_1_at(i)?
+            } else if bit == 0 {
+                public_key.public_key_0_at(i)?
+            } else {
+                warn!("Invalid bit value: {} (expected 0 or 1)", bit);
+                return Ok(false);
+            };
+
+            if hash_of_revealed != *expected_public_key {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
+
+    /// Helper function to generate a hash using HMAC for key derivation
+    fn generate_hash(
+        &self,
+        master_secret: &[u8],
+        key_size: usize,
+        derivation_index: u32,
+        bit_index: u32,
+        bit_value: u8, // 0 or 1
+    ) -> LamportHash {
+        let mut engine = HmacEngine::<sha256::Hash>::new(master_secret);
+        let input = [
+            derivation_index.to_le_bytes(),
+            bit_index.to_le_bytes(),
+            [bit_value, 0, 0, 0],
+        ]
+        .concat();
+        engine.input(&input);
+
+        let hash = Hmac::<sha256::Hash>::from_engine(engine);
+        LamportHash::new(hash[..key_size].to_vec())
+    }
+}
+
+// TODO padding should be added as a parameter, to know how many start 0s are not part of the message, for the funcs that call using exactly all the bits that fits in that bytes padding will be 0
+/// Convert a byte array to a bit array
+/// Each byte is expanded to 8 bits (MSB first)
+pub fn bytes_to_bits(bytes: &[u8]) -> Vec<u8> {
+    let mut bits = Vec::with_capacity(bytes.len() * 8);
+
+    for byte in bytes {
+        for bit_index in 0..8 {
+            let bit = (byte >> (7 - bit_index)) & 1;
+            bits.push(bit);
+        }
+    }
+
+    bits
+}
+
+// TODO padding should be added as a return value, to know how many start 0s of the 1st byte are not part of the message, for the cases converting bits mutiple of 8 the padding will be 0
+/// Convert a bit array back to bytes
+/// Every 8 bits are combined into one byte (MSB first)
+pub fn bits_to_bytes(bits: &[u8]) -> Result<Vec<u8>, LamportError> {
+    if bits.len() % 8 != 0 {
+        return Err(LamportError::InvalidBitLength(bits.len()));
+    }
+
+    let mut bytes = Vec::with_capacity(bits.len() / 8);
+
+    for chunk in bits.chunks(8) {
+        let mut byte = 0u8;
+        for (i, &bit) in chunk.iter().enumerate() {
+            if bit > 1 {
+                return Err(LamportError::InvalidBitValue(bit));
+            }
+            byte |= bit << (7 - i);
+        }
+        bytes.push(byte);
+    }
+
+    Ok(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+
+    // TODO in this test we assume we alsay have the hole byte filled with bits, we should create another tests, where we have 4 bits and padding, (filled with 0s at the begining) and 1 lonely bit with 7 0s as padding
+    #[test]
+    fn test_bytes_to_bits_and_back() {
+        let original_bytes = vec![0b10110011, 0b01001100, 0xFF, 0x00];
+        let bits = bytes_to_bits(&original_bytes);
+        assert_eq!(bits.len(), 32);
+
+        let reconstructed_bytes = bits_to_bytes(&bits).unwrap();
+        assert_eq!(original_bytes, reconstructed_bytes);
+    }
+
+    #[test]
+    fn test_lamport_keygen() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret_12345678901234567890";
+        let message_bit_length = 256; // 32 bytes
+
+        let public_key = lamport
+            .generate_public_key(master_secret, LamportType::SHA256, message_bit_length, 0)
+            .unwrap();
+
+        assert_eq!(public_key.len(), message_bit_length);
+        assert_eq!(public_key.hash_size(), SHA256_SIZE);
+    }
+
+    #[test]
+    fn test_lamport_sign_and_verify() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret_12345678901234567890";
+        let message_bit_length = 256;
+
+        let private_key = lamport
+            .generate_private_key(master_secret, LamportType::SHA256, message_bit_length, 0)
+            .unwrap();
+
+        let public_key = private_key.public_key().unwrap();
+
+        // Create a test message
+        let message_bytes = b"Hello, Lamport!"; // 15 bytes = 120 bits
+        let message_bits = bytes_to_bits(message_bytes);
+
+        // For this test, we need a key with the right bit length
+        let private_key_120 = lamport
+            .generate_private_key(master_secret, LamportType::SHA256, 120, 1)
+            .unwrap();
+        let public_key_120 = private_key_120.public_key().unwrap();
+
+        let signature = lamport.sign_message(&message_bits, &private_key_120).unwrap();
+
+        let is_valid = lamport
+            .verify_signature(&message_bits, &signature, &public_key_120)
+            .unwrap();
+
+        assert!(is_valid);
+    }
+
+    #[test]
+    fn test_lamport_verify_fails_on_wrong_message() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret_12345678901234567890";
+        let message_bit_length = 120;
+
+        let private_key = lamport
+            .generate_private_key(master_secret, LamportType::SHA256, message_bit_length, 0)
+            .unwrap();
+        let public_key = private_key.public_key().unwrap();
+
+        let message_bytes = b"Hello, Lamport!";
+        let message_bits = bytes_to_bits(message_bytes);
+
+        let signature = lamport.sign_message(&message_bits, &private_key).unwrap();
+
+        // Try to verify with a different message
+        let wrong_message_bytes = b"Wrong message!!";
+        let wrong_message_bits = bytes_to_bits(wrong_message_bytes);
+
+        let is_valid = lamport
+            .verify_signature(&wrong_message_bits, &signature, &public_key)
+            .unwrap();
+
+        assert!(!is_valid);
+    }
+
+    #[test]
+    fn test_lamport_serialization() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret_12345678901234567890";
+        let message_bit_length = 256;
+
+        let public_key = lamport
+            .generate_public_key(master_secret, LamportType::SHA256, message_bit_length, 0)
+            .unwrap();
+
+        let bytes = public_key.to_bytes();
+        let reconstructed = LamportPublicKey::from_bytes(&bytes, message_bit_length, LamportType::SHA256).unwrap();
+
+        assert_eq!(public_key.len(), reconstructed.len());
+        assert_eq!(public_key.to_bytes(), reconstructed.to_bytes());
+    }
+
+    #[test]
+    fn test_lamport_type_parsing() {
+        assert_eq!(LamportType::from_str("SHA256").unwrap(), LamportType::SHA256);
+        assert_eq!(LamportType::from_str("sha256").unwrap(), LamportType::SHA256);
+        assert_eq!(LamportType::from_str("HASH160").unwrap(), LamportType::HASH160);
+        assert_eq!(LamportType::from_str("hash160").unwrap(), LamportType::HASH160);
+        assert!(LamportType::from_str("INVALID").is_err());
+    }
+
+    #[test]
+    fn test_lamport_hash160_sign_and_verify() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret_12345678901234567890";
+        let message_bit_length = 160; // 20 bytes for HASH160
+
+        let private_key = lamport
+            .generate_private_key(master_secret, LamportType::HASH160, message_bit_length, 0)
+            .unwrap();
+        let public_key = private_key.public_key().unwrap();
+
+        assert_eq!(public_key.hash_size(), RIPEMD160_SIZE);
+
+        // Create a test message
+        let message_bytes = b"Hello, HASH160!"; // 15 bytes = 120 bits
+        let message_bits = bytes_to_bits(message_bytes);
+
+        let private_key_120 = lamport
+            .generate_private_key(master_secret, LamportType::HASH160, 120, 1)
+            .unwrap();
+        let public_key_120 = private_key_120.public_key().unwrap();
+
+        let signature = lamport.sign_message(&message_bits, &private_key_120).unwrap();
+
+        let is_valid = lamport
+            .verify_signature(&message_bits, &signature, &public_key_120)
+            .unwrap();
+
+        assert!(is_valid);
+    }
+}

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -10,7 +10,14 @@ use crate::errors::LamportError;
 pub const SHA256_SIZE: usize = 32;
 pub const RIPEMD160_SIZE: usize = 20;
 
-// TODO add a max length to prevent DoS with huge keys/signatures?
+/// Maximum message bit length allowed to prevent DoS attacks with huge keys/signatures.
+/// This limit supports up to 10x SHA256 size (256 bits * 10 = 2560 bits) with headroom.
+/// At this limit, key size is approximately: 2 * 10000 * 32 bytes = 625 KB
+pub const MAX_MESSAGE_BIT_LENGTH: usize = 10_000;
+
+/// Maximum signature/key byte length, calculated as MAX_MESSAGE_BIT_LENGTH * max_hash_size * 2
+/// This equals 10,000 * 32 * 2 = 640,000 bytes (~625 KB) for the largest hash type
+pub const MAX_KEY_SIGNATURE_BYTE_LENGTH: usize = MAX_MESSAGE_BIT_LENGTH * SHA256_SIZE * 2;
 
 /// Lamport signature hash function types
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]
@@ -155,6 +162,9 @@ impl LamportSignature {
         message_bit_length: usize,
         hash_type: LamportType,
     ) -> Result<Self, LamportError> {
+        validate_message_bit_length(message_bit_length)?;
+        validate_byte_length(bytes.len())?;
+
         let hash_size = hash_type.hash_size();
 
         if bytes.len() != message_bit_length * hash_size {
@@ -336,6 +346,9 @@ impl LamportPublicKey {
         message_bit_length: usize,
         hash_type: LamportType,
     ) -> Result<Self, LamportError> {
+        validate_message_bit_length(message_bit_length)?;
+        validate_byte_length(bytes_0s_then_1s.len())?;
+
         let hash_size = hash_type.hash_size();
         let expected_length = 2 * message_bit_length * hash_size;
 
@@ -372,6 +385,10 @@ impl LamportPublicKey {
         message_bit_length: usize,
         hash_type: LamportType,
     ) -> Result<Self, LamportError> {
+        validate_message_bit_length(message_bit_length)?;
+        let combined_length = bytes_0s.len().saturating_add(bytes_1s.len());
+        validate_byte_length(combined_length)?;
+
         let hash_size = hash_type.hash_size();
         let expected_length = message_bit_length * hash_size;
 
@@ -511,6 +528,7 @@ impl LamportPrivateKey {
         message_bit_length: usize,
         derivation_index: u32,
     ) -> Self {
+        // Note: Validation is performed in generate_private_key and from_bytes methods
         LamportPrivateKey {
             private_key_0s: Vec::with_capacity(message_bit_length),
             private_key_1s: Vec::with_capacity(message_bit_length),
@@ -576,6 +594,9 @@ impl LamportPrivateKey {
         hash_type: LamportType,
         derivation_index: u32,
     ) -> Result<Self, LamportError> {
+        validate_message_bit_length(message_bit_length)?;
+        validate_byte_length(bytes_0s_then_1s.len())?;
+
         let hash_size = hash_type.hash_size();
         let expected_length = 2 * message_bit_length * hash_size;
 
@@ -613,6 +634,10 @@ impl LamportPrivateKey {
         hash_type: LamportType,
         derivation_index: u32,
     ) -> Result<Self, LamportError> {
+        validate_message_bit_length(message_bit_length)?;
+        let combined_length = bytes_0s.len().saturating_add(bytes_1s.len());
+        validate_byte_length(combined_length)?;
+
         let hash_size = hash_type.hash_size();
         let expected_length = message_bit_length * hash_size;
 
@@ -753,6 +778,32 @@ impl Drop for LamportPrivateKey {
     }
 }
 
+// ========== Validation Helper Functions ==========
+
+/// Validates that message bit length doesn't exceed the maximum to prevent DoS attacks
+fn validate_message_bit_length(message_bit_length: usize) -> Result<(), LamportError> {
+    if message_bit_length > MAX_MESSAGE_BIT_LENGTH {
+        return Err(LamportError::MessageBitLengthExceedsMax(
+            message_bit_length,
+            MAX_MESSAGE_BIT_LENGTH,
+        ));
+    }
+    Ok(())
+}
+
+/// Validates that byte length doesn't exceed the maximum to prevent DoS attacks
+fn validate_byte_length(byte_length: usize) -> Result<(), LamportError> {
+    if byte_length > MAX_KEY_SIGNATURE_BYTE_LENGTH {
+        return Err(LamportError::ByteLengthExceedsMax(
+            byte_length,
+            MAX_KEY_SIGNATURE_BYTE_LENGTH,
+        ));
+    }
+    Ok(())
+}
+
+// ========== Main Lamport Implementation ==========
+
 /// Main Lamport signature scheme implementation
 #[derive(Default)]
 pub struct Lamport {}
@@ -808,6 +859,8 @@ impl Lamport {
         message_bit_length: usize,
         derivation_index: u32,
     ) -> Result<LamportPrivateKey, LamportError> {
+        validate_message_bit_length(message_bit_length)?;
+
         derivation_index
             .checked_add(1)
             .ok_or(LamportError::IndexOverflow)?;
@@ -2272,5 +2325,148 @@ mod tests {
         let message_bytes = vec![0x42u8; 128]; // 1024 bits
         let signature = lamport.sign_message_bytes(&message_bytes, &private_key).unwrap();
         assert!(lamport.verify_signature_bytes(&message_bytes, &signature, &public_key).unwrap());
+    }
+
+    // ========== DoS Protection Tests ==========
+
+    #[test]
+    fn test_dos_protection_exceeds_max_message_bit_length() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret";
+
+        // Try to generate with message_bit_length exceeding MAX_MESSAGE_BIT_LENGTH
+        let result = lamport.generate_private_key(
+            master_secret,
+            LamportType::SHA256,
+            MAX_MESSAGE_BIT_LENGTH + 1,
+            0,
+        );
+
+        assert!(result.is_err());
+        match result {
+            Err(LamportError::MessageBitLengthExceedsMax(actual, max)) => {
+                assert_eq!(actual, MAX_MESSAGE_BIT_LENGTH + 1);
+                assert_eq!(max, MAX_MESSAGE_BIT_LENGTH);
+            }
+            _ => panic!("Expected MessageBitLengthExceedsMax error"),
+        }
+    }
+
+    #[test]
+    fn test_dos_protection_at_max_message_bit_length() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret";
+
+        // Exactly at MAX_MESSAGE_BIT_LENGTH should succeed (might be slow, but validates the limit)
+        let result = lamport.generate_private_key(
+            master_secret,
+            LamportType::SHA256,
+            MAX_MESSAGE_BIT_LENGTH,
+            0,
+        );
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_dos_protection_public_key_from_bytes() {
+        // Try to deserialize with excessive message_bit_length
+        let result = LamportPublicKey::from_bytes(
+            &[0u8; 100],
+            MAX_MESSAGE_BIT_LENGTH + 1,
+            LamportType::SHA256,
+        );
+
+        assert!(result.is_err());
+        match result {
+            Err(LamportError::MessageBitLengthExceedsMax(actual, max)) => {
+                assert_eq!(actual, MAX_MESSAGE_BIT_LENGTH + 1);
+                assert_eq!(max, MAX_MESSAGE_BIT_LENGTH);
+            }
+            _ => panic!("Expected MessageBitLengthExceedsMax error"),
+        }
+    }
+
+    #[test]
+    fn test_dos_protection_public_key_from_bytes_excessive_bytes() {
+        // Create a huge byte array that exceeds MAX_KEY_SIGNATURE_BYTE_LENGTH
+        // We don't actually allocate it, just pass the length check
+        let large_vec = vec![0u8; 1000]; // Small allocation for the test
+
+        // Try with a message_bit_length that would require more bytes than MAX
+        let result = LamportPublicKey::from_bytes(
+            &large_vec,
+            MAX_MESSAGE_BIT_LENGTH,
+            LamportType::SHA256,
+        );
+
+        // Should fail because bytes length (1000) doesn't match expected (MAX_MESSAGE_BIT_LENGTH * 32 * 2)
+        // but more importantly, it validates limits before trying to process
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_dos_protection_private_key_from_bytes() {
+        // Try to deserialize with excessive message_bit_length
+        let result = LamportPrivateKey::from_bytes(
+            &[0u8; 100],
+            MAX_MESSAGE_BIT_LENGTH + 1,
+            LamportType::SHA256,
+            0,
+        );
+
+        assert!(result.is_err());
+        match result {
+            Err(LamportError::MessageBitLengthExceedsMax(actual, max)) => {
+                assert_eq!(actual, MAX_MESSAGE_BIT_LENGTH + 1);
+                assert_eq!(max, MAX_MESSAGE_BIT_LENGTH);
+            }
+            _ => panic!("Expected MessageBitLengthExceedsMax error"),
+        }
+    }
+
+    #[test]
+    fn test_dos_protection_signature_from_bytes() {
+        // Try to deserialize with excessive message_bit_length
+        let result = LamportSignature::from_bytes(
+            &[0u8; 100],
+            MAX_MESSAGE_BIT_LENGTH + 1,
+            LamportType::SHA256,
+        );
+
+        assert!(result.is_err());
+        match result {
+            Err(LamportError::MessageBitLengthExceedsMax(actual, max)) => {
+                assert_eq!(actual, MAX_MESSAGE_BIT_LENGTH + 1);
+                assert_eq!(max, MAX_MESSAGE_BIT_LENGTH);
+            }
+            _ => panic!("Expected MessageBitLengthExceedsMax error"),
+        }
+    }
+
+    #[test]
+    fn test_dos_protection_from_bytes_splitted() {
+        // Test both public and private key from_bytes_splitted methods
+        let bytes_0s = vec![0u8; 100];
+        let bytes_1s = vec![0u8; 100];
+
+        // Test public key
+        let result = LamportPublicKey::from_bytes_splitted(
+            &bytes_0s,
+            &bytes_1s,
+            MAX_MESSAGE_BIT_LENGTH + 1,
+            LamportType::SHA256,
+        );
+        assert!(result.is_err());
+
+        // Test private key
+        let result = LamportPrivateKey::from_bytes_splitted(
+            &bytes_0s,
+            &bytes_1s,
+            MAX_MESSAGE_BIT_LENGTH + 1,
+            LamportType::SHA256,
+            0,
+        );
+        assert!(result.is_err());
     }
 }

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -1554,8 +1554,14 @@ mod tests {
             .unwrap();
 
         let bytes = public_key.to_bytes();
-        let reconstructed =
-            LamportPublicKey::from_bytes(&bytes, message_bit_length, LamportType::SHA256, false, Some(ExtraData::new(message_bit_length, Some(0)))).unwrap();
+        let reconstructed = LamportPublicKey::from_bytes(
+            &bytes,
+            message_bit_length,
+            LamportType::SHA256,
+            false,
+            Some(ExtraData::new(message_bit_length, Some(0))),
+        )
+        .unwrap();
 
         assert_eq!(public_key.len(), reconstructed.len());
         assert_eq!(public_key.to_bytes(), reconstructed.to_bytes());
@@ -2044,9 +2050,14 @@ mod tests {
             .unwrap();
 
         let bytes = private_key.to_bytes();
-        let reconstructed =
-            LamportPrivateKey::from_bytes(&bytes, message_bit_length, LamportType::SHA256, Some(0), false)
-                .unwrap();
+        let reconstructed = LamportPrivateKey::from_bytes(
+            &bytes,
+            message_bit_length,
+            LamportType::SHA256,
+            Some(0),
+            false,
+        )
+        .unwrap();
 
         assert_eq!(private_key.len(), reconstructed.len());
         assert_eq!(private_key.to_bytes(), reconstructed.to_bytes());
@@ -2625,8 +2636,13 @@ mod tests {
         let large_vec = vec![0u8; 1000]; // Small allocation for the test
 
         // Try with a message_bit_length that would require more bytes than MAX
-        let result =
-            LamportPublicKey::from_bytes(&large_vec, MAX_MESSAGE_BIT_LENGTH, LamportType::SHA256, false, None);
+        let result = LamportPublicKey::from_bytes(
+            &large_vec,
+            MAX_MESSAGE_BIT_LENGTH,
+            LamportType::SHA256,
+            false,
+            None,
+        );
 
         // Should fail because bytes length (1000) doesn't match expected (MAX_MESSAGE_BIT_LENGTH * 32 * 2)
         // but more importantly, it validates limits before trying to process

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -230,7 +230,10 @@ impl LamportSignature {
     fn revealed_key_at(&self, index: usize) -> Result<&LamportHash, LamportError> {
         self.revealed_keys
             .get(index)
-            .ok_or(LamportError::IndexOutOfBounds(index, self.revealed_keys.len()))
+            .ok_or(LamportError::IndexOutOfBounds(
+                index,
+                self.revealed_keys.len(),
+            ))
     }
 }
 
@@ -436,16 +439,30 @@ impl LamportPublicKey {
     }
 
     pub fn to_array_hashes(&self) -> Result<(Vec<[u8; 32]>, Vec<[u8; 32]>), LamportError> {
-        let hashes_0s: Result<Vec<[u8; 32]>, LamportError> =
-            self.public_key_0s.iter().map(|hash| hash.to_array()).collect();
-        let hashes_1s: Result<Vec<[u8; 32]>, LamportError> =
-            self.public_key_1s.iter().map(|hash| hash.to_array()).collect();
+        let hashes_0s: Result<Vec<[u8; 32]>, LamportError> = self
+            .public_key_0s
+            .iter()
+            .map(|hash| hash.to_array())
+            .collect();
+        let hashes_1s: Result<Vec<[u8; 32]>, LamportError> = self
+            .public_key_1s
+            .iter()
+            .map(|hash| hash.to_array())
+            .collect();
         Ok((hashes_0s?, hashes_1s?))
     }
 
     pub fn to_hashes_string(&self) -> (Vec<String>, Vec<String>) {
-        let hashes_0s = self.public_key_0s.iter().map(|hash| hash.to_hex()).collect();
-        let hashes_1s = self.public_key_1s.iter().map(|hash| hash.to_hex()).collect();
+        let hashes_0s = self
+            .public_key_0s
+            .iter()
+            .map(|hash| hash.to_hex())
+            .collect();
+        let hashes_1s = self
+            .public_key_1s
+            .iter()
+            .map(|hash| hash.to_hex())
+            .collect();
         (hashes_0s, hashes_1s)
     }
 
@@ -497,13 +514,19 @@ impl LamportPublicKey {
     fn public_key_0_at(&self, index: usize) -> Result<&LamportHash, LamportError> {
         self.public_key_0s
             .get(index)
-            .ok_or(LamportError::IndexOutOfBounds(index, self.public_key_0s.len()))
+            .ok_or(LamportError::IndexOutOfBounds(
+                index,
+                self.public_key_0s.len(),
+            ))
     }
 
     fn public_key_1_at(&self, index: usize) -> Result<&LamportHash, LamportError> {
         self.public_key_1s
             .get(index)
-            .ok_or(LamportError::IndexOutOfBounds(index, self.public_key_1s.len()))
+            .ok_or(LamportError::IndexOutOfBounds(
+                index,
+                self.public_key_1s.len(),
+            ))
     }
 }
 
@@ -542,7 +565,10 @@ impl LamportPrivateKey {
     pub fn public_key(&self) -> Result<LamportPublicKey, LamportError> {
         let mut public_key = LamportPublicKey::new(
             self.hash_type,
-            Some(ExtraData::new(self.message_bit_length, self.derivation_index)),
+            Some(ExtraData::new(
+                self.message_bit_length,
+                self.derivation_index,
+            )),
         );
 
         for i in 0..self.private_key_0s.len() {
@@ -608,7 +634,8 @@ impl LamportPrivateKey {
             ));
         }
 
-        let mut private_key = LamportPrivateKey::new(hash_type, message_bit_length, derivation_index);
+        let mut private_key =
+            LamportPrivateKey::new(hash_type, message_bit_length, derivation_index);
 
         // Split bytes into 0s and 1s sections
         let split_point = message_bit_length * hash_size;
@@ -656,7 +683,8 @@ impl LamportPrivateKey {
             ));
         }
 
-        let mut private_key = LamportPrivateKey::new(hash_type, message_bit_length, derivation_index);
+        let mut private_key =
+            LamportPrivateKey::new(hash_type, message_bit_length, derivation_index);
 
         for i in 0..message_bit_length {
             let start = i * hash_size;
@@ -670,7 +698,6 @@ impl LamportPrivateKey {
 
         Ok(private_key)
     }
-
 
     pub fn to_hashes(&self) -> (Vec<Vec<u8>>, Vec<Vec<u8>>) {
         let hashes_0s = self
@@ -701,8 +728,16 @@ impl LamportPrivateKey {
     }
 
     pub fn to_hashes_string(&self) -> (Vec<String>, Vec<String>) {
-        let hashes_0s = self.private_key_0s.iter().map(|hash| hash.to_hex()).collect();
-        let hashes_1s = self.private_key_1s.iter().map(|hash| hash.to_hex()).collect();
+        let hashes_0s = self
+            .private_key_0s
+            .iter()
+            .map(|hash| hash.to_hex())
+            .collect();
+        let hashes_1s = self
+            .private_key_1s
+            .iter()
+            .map(|hash| hash.to_hex())
+            .collect();
         (hashes_0s, hashes_1s)
     }
 
@@ -757,13 +792,19 @@ impl LamportPrivateKey {
     fn private_key_0_at(&self, index: usize) -> Result<&LamportHash, LamportError> {
         self.private_key_0s
             .get(index)
-            .ok_or(LamportError::IndexOutOfBounds(index, self.private_key_0s.len()))
+            .ok_or(LamportError::IndexOutOfBounds(
+                index,
+                self.private_key_0s.len(),
+            ))
     }
 
     fn private_key_1_at(&self, index: usize) -> Result<&LamportHash, LamportError> {
         self.private_key_1s
             .get(index)
-            .ok_or(LamportError::IndexOutOfBounds(index, self.private_key_1s.len()))
+            .ok_or(LamportError::IndexOutOfBounds(
+                index,
+                self.private_key_1s.len(),
+            ))
     }
 }
 
@@ -832,8 +873,12 @@ impl Lamport {
         message_bit_length: usize,
         derivation_index: u32,
     ) -> Result<LamportPublicKey, LamportError> {
-        let private_key =
-            self.generate_private_key(master_secret, hash_type, message_bit_length, derivation_index)?;
+        let private_key = self.generate_private_key(
+            master_secret,
+            hash_type,
+            message_bit_length,
+            derivation_index,
+        )?;
         let public_key = LamportPublicKey::from(private_key)?;
         Ok(public_key)
     }
@@ -874,17 +919,18 @@ impl Lamport {
         // Generate key pairs for each bit position
         for i in 0..message_bit_length {
             // Generate private key for bit value 0
-            let priv_key_0 = self.generate_hash(master_secret, hash_size, derivation_index, i as u32, 0);
+            let priv_key_0 =
+                self.generate_hash(master_secret, hash_size, derivation_index, i as u32, 0);
 
             // Generate private key for bit value 1
-            let priv_key_1 = self.generate_hash(master_secret, hash_size, derivation_index, i as u32, 1);
+            let priv_key_1 =
+                self.generate_hash(master_secret, hash_size, derivation_index, i as u32, 1);
 
             private_key.push_key_pair(priv_key_0, priv_key_1)?;
         }
 
         Ok(private_key)
     }
-
 
     /// Sign a message using a Lamport private key
     ///
@@ -1199,7 +1245,6 @@ pub fn bits_to_bytes(bits: &[bool]) -> Result<(Vec<u8>, usize), LamportError> {
 mod tests {
     use super::*;
 
-
     #[test]
     fn test_bytes_to_bits_and_back() {
         // Test with no padding (full bytes)
@@ -1287,8 +1332,8 @@ mod tests {
 
         // Test with 0 padding (exact byte boundary - 16 bits)
         let bits = vec![
-            true, false, true, true, false, false, true, true,
-            false, true, false, false, true, true, false, false
+            true, false, true, true, false, false, true, true, false, true, false, false, true,
+            true, false, false,
         ];
         let (bytes, padding) = bits_to_bytes(&bits).unwrap();
         assert_eq!(padding, 0);
@@ -1324,10 +1369,13 @@ mod tests {
         let bytes = vec![0xFF, 0b11110101, 0xAA];
         let bits = bytes_to_bits(&bytes, 12);
         assert_eq!(bits.len(), 12);
-        assert_eq!(bits, vec![
-            false, true, false, true, // lower 4 bits of 0b11110101
-            true, false, true, false, true, false, true, false // 0xAA
-        ]);
+        assert_eq!(
+            bits,
+            vec![
+                false, true, false, true, // lower 4 bits of 0b11110101
+                true, false, true, false, true, false, true, false // 0xAA
+            ]
+        );
 
         // Test with padding = 15 (almost 2 bytes)
         // bytes = [0x00, 0xFF, 0x01] = 24 bits total
@@ -1336,7 +1384,10 @@ mod tests {
         let bytes = vec![0x00, 0xFF, 0x01];
         let bits = bytes_to_bits(&bytes, 15);
         assert_eq!(bits.len(), 9);
-        assert_eq!(bits, vec![true, false, false, false, false, false, false, false, true]);
+        assert_eq!(
+            bits,
+            vec![true, false, false, false, false, false, false, false, true]
+        );
     }
 
     #[test]
@@ -1404,7 +1455,9 @@ mod tests {
             .unwrap();
         let public_key_120 = private_key_120.public_key().unwrap();
 
-        let signature = lamport.sign_message(&message_bits, &private_key_120).unwrap();
+        let signature = lamport
+            .sign_message(&message_bits, &private_key_120)
+            .unwrap();
 
         let is_valid = lamport
             .verify_signature(&message_bits, &signature, &public_key_120)
@@ -1451,7 +1504,8 @@ mod tests {
             .unwrap();
 
         let bytes = public_key.to_bytes();
-        let reconstructed = LamportPublicKey::from_bytes(&bytes, message_bit_length, LamportType::SHA256).unwrap();
+        let reconstructed =
+            LamportPublicKey::from_bytes(&bytes, message_bit_length, LamportType::SHA256).unwrap();
 
         assert_eq!(public_key.len(), reconstructed.len());
         assert_eq!(public_key.to_bytes(), reconstructed.to_bytes());
@@ -1459,10 +1513,22 @@ mod tests {
 
     #[test]
     fn test_lamport_type_parsing() {
-        assert_eq!(LamportType::from_str("SHA256").unwrap(), LamportType::SHA256);
-        assert_eq!(LamportType::from_str("sha256").unwrap(), LamportType::SHA256);
-        assert_eq!(LamportType::from_str("HASH160").unwrap(), LamportType::HASH160);
-        assert_eq!(LamportType::from_str("hash160").unwrap(), LamportType::HASH160);
+        assert_eq!(
+            LamportType::from_str("SHA256").unwrap(),
+            LamportType::SHA256
+        );
+        assert_eq!(
+            LamportType::from_str("sha256").unwrap(),
+            LamportType::SHA256
+        );
+        assert_eq!(
+            LamportType::from_str("HASH160").unwrap(),
+            LamportType::HASH160
+        );
+        assert_eq!(
+            LamportType::from_str("hash160").unwrap(),
+            LamportType::HASH160
+        );
         assert!(LamportType::from_str("INVALID").is_err());
     }
 
@@ -1488,7 +1554,9 @@ mod tests {
             .unwrap();
         let public_key_120 = private_key_120.public_key().unwrap();
 
-        let signature = lamport.sign_message(&message_bits, &private_key_120).unwrap();
+        let signature = lamport
+            .sign_message(&message_bits, &private_key_120)
+            .unwrap();
 
         let is_valid = lamport
             .verify_signature(&message_bits, &signature, &public_key_120)
@@ -1511,7 +1579,9 @@ mod tests {
             .unwrap();
         let public_key = private_key.public_key().unwrap();
 
-        let signature = lamport.sign_message_bytes(&message_bytes, &private_key).unwrap();
+        let signature = lamport
+            .sign_message_bytes(&message_bytes, &private_key)
+            .unwrap();
 
         let is_valid = lamport
             .verify_signature_bytes(&message_bytes, &signature, &public_key)
@@ -1541,14 +1611,20 @@ mod tests {
         let public_key = private_key.public_key().unwrap();
 
         // Sign with bytes method
-        let sig_bytes = lamport.sign_message_bytes(message_bytes, &private_key).unwrap();
+        let sig_bytes = lamport
+            .sign_message_bytes(message_bytes, &private_key)
+            .unwrap();
 
         // Verify bytes signature with bytes method
-        assert!(lamport.verify_signature_bytes(message_bytes, &sig_bytes, &public_key).unwrap());
+        assert!(lamport
+            .verify_signature_bytes(message_bytes, &sig_bytes, &public_key)
+            .unwrap());
 
         // Verify bytes signature with bits method (should also work)
         let message_bits = bytes_to_bits(message_bytes, 0);
-        assert!(lamport.verify_signature(&message_bits, &sig_bytes, &public_key).unwrap());
+        assert!(lamport
+            .verify_signature(&message_bits, &sig_bytes, &public_key)
+            .unwrap());
     }
 
     #[test]
@@ -1562,11 +1638,18 @@ mod tests {
             let message_bit_length = byte_length * 8;
 
             let private_key = lamport
-                .generate_private_key(master_secret, LamportType::SHA256, message_bit_length, byte_length as u32)
+                .generate_private_key(
+                    master_secret,
+                    LamportType::SHA256,
+                    message_bit_length,
+                    byte_length as u32,
+                )
                 .unwrap();
             let public_key = private_key.public_key().unwrap();
 
-            let signature = lamport.sign_message_bytes(&message_bytes, &private_key).unwrap();
+            let signature = lamport
+                .sign_message_bytes(&message_bytes, &private_key)
+                .unwrap();
 
             let is_valid = lamport
                 .verify_signature_bytes(&message_bytes, &signature, &public_key)
@@ -1588,19 +1671,27 @@ mod tests {
             .unwrap();
         let public_key = private_key.public_key().unwrap();
 
-        let signature = lamport.sign_message_bytes(&message_bytes, &private_key).unwrap();
+        let signature = lamport
+            .sign_message_bytes(&message_bytes, &private_key)
+            .unwrap();
 
         // Original message should verify
-        assert!(lamport.verify_signature_bytes(&message_bytes, &signature, &public_key).unwrap());
+        assert!(lamport
+            .verify_signature_bytes(&message_bytes, &signature, &public_key)
+            .unwrap());
 
         // Tampered message (single bit flip) should fail
         let mut tampered_message = message_bytes;
         tampered_message[0] = 0x43; // Change one byte
-        assert!(!lamport.verify_signature_bytes(&tampered_message, &signature, &public_key).unwrap());
+        assert!(!lamport
+            .verify_signature_bytes(&tampered_message, &signature, &public_key)
+            .unwrap());
 
         // Completely different message should fail
         let different_message = [0xFFu8; 32];
-        assert!(!lamport.verify_signature_bytes(&different_message, &signature, &public_key).unwrap());
+        assert!(!lamport
+            .verify_signature_bytes(&different_message, &signature, &public_key)
+            .unwrap());
     }
 
     #[test]
@@ -1616,8 +1707,12 @@ mod tests {
 
         // Test signing bit value 0
         let signature_0 = lamport.sign_message_bit(false, &private_key_bit0).unwrap();
-        assert!(lamport.verify_signature_bit(false, &signature_0, &public_key_bit0).unwrap());
-        assert!(!lamport.verify_signature_bit(true, &signature_0, &public_key_bit0).unwrap());
+        assert!(lamport
+            .verify_signature_bit(false, &signature_0, &public_key_bit0)
+            .unwrap());
+        assert!(!lamport
+            .verify_signature_bit(true, &signature_0, &public_key_bit0)
+            .unwrap());
 
         // Generate another key for signing bit value 1
         let private_key_bit1 = lamport
@@ -1627,8 +1722,12 @@ mod tests {
 
         // Test signing bit value 1
         let signature_1 = lamport.sign_message_bit(true, &private_key_bit1).unwrap();
-        assert!(lamport.verify_signature_bit(true, &signature_1, &public_key_bit1).unwrap());
-        assert!(!lamport.verify_signature_bit(false, &signature_1, &public_key_bit1).unwrap());
+        assert!(lamport
+            .verify_signature_bit(true, &signature_1, &public_key_bit1)
+            .unwrap());
+        assert!(!lamport
+            .verify_signature_bit(false, &signature_1, &public_key_bit1)
+            .unwrap());
     }
 
     #[test]
@@ -1646,10 +1745,14 @@ mod tests {
 
         // Verify using array method
         let message_bits = [true];
-        assert!(lamport.verify_signature(&message_bits, &sig_bit, &public_key).unwrap());
+        assert!(lamport
+            .verify_signature(&message_bits, &sig_bit, &public_key)
+            .unwrap());
 
         // Verify using bit method
-        assert!(lamport.verify_signature_bit(true, &sig_bit, &public_key).unwrap());
+        assert!(lamport
+            .verify_signature_bit(true, &sig_bit, &public_key)
+            .unwrap());
     }
 
     #[test]
@@ -1710,13 +1813,19 @@ mod tests {
         assert_eq!(public_key.hash_type(), LamportType::RIPEMD160);
 
         let message_bytes = [0x42u8; 20]; // Sign a 20-byte message
-        let signature = lamport.sign_message_bytes(&message_bytes, &private_key).unwrap();
+        let signature = lamport
+            .sign_message_bytes(&message_bytes, &private_key)
+            .unwrap();
 
-        assert!(lamport.verify_signature_bytes(&message_bytes, &signature, &public_key).unwrap());
+        assert!(lamport
+            .verify_signature_bytes(&message_bytes, &signature, &public_key)
+            .unwrap());
 
         // Test with wrong message
         let wrong_message = [0x43u8; 20];
-        assert!(!lamport.verify_signature_bytes(&wrong_message, &signature, &public_key).unwrap());
+        assert!(!lamport
+            .verify_signature_bytes(&wrong_message, &signature, &public_key)
+            .unwrap());
     }
 
     #[test]
@@ -1734,13 +1843,19 @@ mod tests {
         assert_eq!(public_key.hash_type(), LamportType::HASH256);
 
         let message_bytes = [0xAAu8; 32]; // Sign a 32-byte message
-        let signature = lamport.sign_message_bytes(&message_bytes, &private_key).unwrap();
+        let signature = lamport
+            .sign_message_bytes(&message_bytes, &private_key)
+            .unwrap();
 
-        assert!(lamport.verify_signature_bytes(&message_bytes, &signature, &public_key).unwrap());
+        assert!(lamport
+            .verify_signature_bytes(&message_bytes, &signature, &public_key)
+            .unwrap());
 
         // Test with wrong message
         let wrong_message = [0xBBu8; 32];
-        assert!(!lamport.verify_signature_bytes(&wrong_message, &signature, &public_key).unwrap());
+        assert!(!lamport
+            .verify_signature_bytes(&wrong_message, &signature, &public_key)
+            .unwrap());
     }
 
     #[test]
@@ -1762,8 +1877,18 @@ mod tests {
                 .unwrap();
             let public_key = private_key.public_key().unwrap();
 
-            assert_eq!(public_key.hash_size(), expected_size, "Hash type: {:?}", hash_type);
-            assert_eq!(private_key.hash_size(), expected_size, "Hash type: {:?}", hash_type);
+            assert_eq!(
+                public_key.hash_size(),
+                expected_size,
+                "Hash type: {:?}",
+                hash_type
+            );
+            assert_eq!(
+                private_key.hash_size(),
+                expected_size,
+                "Hash type: {:?}",
+                hash_type
+            );
         }
     }
 
@@ -1870,18 +1995,20 @@ mod tests {
             .unwrap();
 
         let bytes = private_key.to_bytes();
-        let reconstructed = LamportPrivateKey::from_bytes(
-            &bytes,
-            message_bit_length,
-            LamportType::SHA256,
-            0,
-        )
-        .unwrap();
+        let reconstructed =
+            LamportPrivateKey::from_bytes(&bytes, message_bit_length, LamportType::SHA256, 0)
+                .unwrap();
 
         assert_eq!(private_key.len(), reconstructed.len());
         assert_eq!(private_key.to_bytes(), reconstructed.to_bytes());
-        assert_eq!(private_key.message_bit_length(), reconstructed.message_bit_length());
-        assert_eq!(private_key.derivation_index(), reconstructed.derivation_index());
+        assert_eq!(
+            private_key.message_bit_length(),
+            reconstructed.message_bit_length()
+        );
+        assert_eq!(
+            private_key.derivation_index(),
+            reconstructed.derivation_index()
+        );
     }
 
     #[test]
@@ -1905,7 +2032,10 @@ mod tests {
         .unwrap();
 
         assert_eq!(private_key.to_bytes(), reconstructed.to_bytes());
-        assert_eq!(private_key.derivation_index(), reconstructed.derivation_index());
+        assert_eq!(
+            private_key.derivation_index(),
+            reconstructed.derivation_index()
+        );
     }
 
     #[test]
@@ -1942,19 +2072,20 @@ mod tests {
             .unwrap();
 
         let message_bytes = [0x42u8; 16]; // 128 bits
-        let signature = lamport.sign_message_bytes(&message_bytes, &private_key).unwrap();
+        let signature = lamport
+            .sign_message_bytes(&message_bytes, &private_key)
+            .unwrap();
 
         let bytes = signature.to_bytes();
-        let reconstructed = LamportSignature::from_bytes(
-            &bytes,
-            message_bit_length,
-            LamportType::SHA256,
-        )
-        .unwrap();
+        let reconstructed =
+            LamportSignature::from_bytes(&bytes, message_bit_length, LamportType::SHA256).unwrap();
 
         assert_eq!(signature.len(), reconstructed.len());
         assert_eq!(signature.to_bytes(), reconstructed.to_bytes());
-        assert_eq!(signature.message_bit_length(), reconstructed.message_bit_length());
+        assert_eq!(
+            signature.message_bit_length(),
+            reconstructed.message_bit_length()
+        );
     }
 
     // ========== Array Conversion Tests ==========
@@ -2007,7 +2138,9 @@ mod tests {
             .unwrap();
 
         let message_bytes = [0x42u8; 2]; // 16 bits
-        let signature = lamport.sign_message_bytes(&message_bytes, &private_key).unwrap();
+        let signature = lamport
+            .sign_message_bytes(&message_bytes, &private_key)
+            .unwrap();
 
         let result = signature.to_array_hashes();
         assert!(result.is_ok());
@@ -2039,7 +2172,9 @@ mod tests {
 
         // Test signature to_hashes
         let message_bytes = [0x42u8; 1];
-        let signature = lamport.sign_message_bytes(&message_bytes, &private_key).unwrap();
+        let signature = lamport
+            .sign_message_bytes(&message_bytes, &private_key)
+            .unwrap();
         let sig_hashes = signature.to_hashes();
         assert_eq!(sig_hashes.len(), message_bit_length);
     }
@@ -2086,7 +2221,12 @@ mod tests {
         let derivation_index = 99;
 
         let private_key = lamport
-            .generate_private_key(master_secret, LamportType::SHA256, message_bit_length, derivation_index)
+            .generate_private_key(
+                master_secret,
+                LamportType::SHA256,
+                message_bit_length,
+                derivation_index,
+            )
             .unwrap();
         let public_key = private_key.public_key().unwrap();
 
@@ -2108,7 +2248,9 @@ mod tests {
             .generate_private_key(master_secret, LamportType::SHA256, message_bit_length, 0)
             .unwrap();
         let message_bytes = [0x42u8; 16];
-        let signature = lamport.sign_message_bytes(&message_bytes, &private_key_sha256).unwrap();
+        let signature = lamport
+            .sign_message_bytes(&message_bytes, &private_key_sha256)
+            .unwrap();
 
         // Try to verify with a HASH160 public key (different hash type)
         let private_key_hash160 = lamport
@@ -2117,7 +2259,9 @@ mod tests {
         let public_key_hash160 = private_key_hash160.public_key().unwrap();
 
         // This should fail because hash types don't match
-        let is_valid = lamport.verify_signature_bytes(&message_bytes, &signature, &public_key_hash160).unwrap();
+        let is_valid = lamport
+            .verify_signature_bytes(&message_bytes, &signature, &public_key_hash160)
+            .unwrap();
         assert!(!is_valid);
     }
 
@@ -2182,7 +2326,9 @@ mod tests {
             .unwrap();
 
         let message_bytes = [0x42u8; 8];
-        let signature = lamport.sign_message_bytes(&message_bytes, &private_key).unwrap();
+        let signature = lamport
+            .sign_message_bytes(&message_bytes, &private_key)
+            .unwrap();
 
         assert_eq!(signature.len(), message_bit_length);
         assert!(!signature.is_empty());
@@ -2234,12 +2380,27 @@ mod tests {
     #[test]
     fn test_lamport_type_parsing_all_variants() {
         // Test case insensitivity
-        assert_eq!(LamportType::from_str("SHA256").unwrap(), LamportType::SHA256);
-        assert_eq!(LamportType::from_str("sha256").unwrap(), LamportType::SHA256);
-        assert_eq!(LamportType::from_str("SHa256").unwrap(), LamportType::SHA256);
+        assert_eq!(
+            LamportType::from_str("SHA256").unwrap(),
+            LamportType::SHA256
+        );
+        assert_eq!(
+            LamportType::from_str("sha256").unwrap(),
+            LamportType::SHA256
+        );
+        assert_eq!(
+            LamportType::from_str("SHa256").unwrap(),
+            LamportType::SHA256
+        );
 
-        assert_eq!(LamportType::from_str("HASH160").unwrap(), LamportType::HASH160);
-        assert_eq!(LamportType::from_str("hash160").unwrap(), LamportType::HASH160);
+        assert_eq!(
+            LamportType::from_str("HASH160").unwrap(),
+            LamportType::HASH160
+        );
+        assert_eq!(
+            LamportType::from_str("hash160").unwrap(),
+            LamportType::HASH160
+        );
 
         // Test invalid types
         assert!(LamportType::from_str("RIPEMD160").is_err());
@@ -2280,10 +2441,20 @@ mod tests {
 
         // Generate the same key twice
         let key1 = lamport
-            .generate_private_key(master_secret, LamportType::SHA256, message_bit_length, derivation_index)
+            .generate_private_key(
+                master_secret,
+                LamportType::SHA256,
+                message_bit_length,
+                derivation_index,
+            )
             .unwrap();
         let key2 = lamport
-            .generate_private_key(master_secret, LamportType::SHA256, message_bit_length, derivation_index)
+            .generate_private_key(
+                master_secret,
+                LamportType::SHA256,
+                message_bit_length,
+                derivation_index,
+            )
             .unwrap();
 
         // They should be identical
@@ -2304,7 +2475,8 @@ mod tests {
         assert!(result.is_err());
 
         // u32::MAX - 1 should succeed
-        let result = lamport.generate_private_key(master_secret, LamportType::SHA256, 8, u32::MAX - 1);
+        let result =
+            lamport.generate_private_key(master_secret, LamportType::SHA256, 8, u32::MAX - 1);
         assert!(result.is_ok());
     }
 
@@ -2324,8 +2496,12 @@ mod tests {
 
         // Sign and verify a large message
         let message_bytes = vec![0x42u8; 128]; // 1024 bits
-        let signature = lamport.sign_message_bytes(&message_bytes, &private_key).unwrap();
-        assert!(lamport.verify_signature_bytes(&message_bytes, &signature, &public_key).unwrap());
+        let signature = lamport
+            .sign_message_bytes(&message_bytes, &private_key)
+            .unwrap();
+        assert!(lamport
+            .verify_signature_bytes(&message_bytes, &signature, &public_key)
+            .unwrap());
     }
 
     // ========== DoS Protection Tests ==========
@@ -2395,11 +2571,8 @@ mod tests {
         let large_vec = vec![0u8; 1000]; // Small allocation for the test
 
         // Try with a message_bit_length that would require more bytes than MAX
-        let result = LamportPublicKey::from_bytes(
-            &large_vec,
-            MAX_MESSAGE_BIT_LENGTH,
-            LamportType::SHA256,
-        );
+        let result =
+            LamportPublicKey::from_bytes(&large_vec, MAX_MESSAGE_BIT_LENGTH, LamportType::SHA256);
 
         // Should fail because bytes length (1000) doesn't match expected (MAX_MESSAGE_BIT_LENGTH * 32 * 2)
         // but more importantly, it validates limits before trying to process

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -929,6 +929,60 @@ fn validate_imported_and_derivation_consistency(
     Ok(())
 }
 
+// ========== LamportMessage Trait ==========
+
+/// Trait for types that can be used as a Lamport message in `verify_signature`.
+///
+/// Implemented for:
+/// - `bool` — single-bit message
+/// - `&[bool]` / `&Vec<bool>` / `&[bool; N]` — multi-bit messages
+/// - `&[u8]` / `&Vec<u8>` / `&[u8; N]` — byte messages (bits derived MSB-first)
+pub trait LamportMessage {
+    fn into_message_bits(self) -> Vec<bool>;
+}
+
+impl LamportMessage for bool {
+    fn into_message_bits(self) -> Vec<bool> {
+        vec![self]
+    }
+}
+
+impl LamportMessage for &[bool] {
+    fn into_message_bits(self) -> Vec<bool> {
+        self.to_vec()
+    }
+}
+
+impl LamportMessage for &Vec<bool> {
+    fn into_message_bits(self) -> Vec<bool> {
+        self.to_vec()
+    }
+}
+
+impl<const N: usize> LamportMessage for &[bool; N] {
+    fn into_message_bits(self) -> Vec<bool> {
+        self.to_vec()
+    }
+}
+
+impl LamportMessage for &[u8] {
+    fn into_message_bits(self) -> Vec<bool> {
+        bytes_to_bits(self, 0)
+    }
+}
+
+impl LamportMessage for &Vec<u8> {
+    fn into_message_bits(self) -> Vec<bool> {
+        bytes_to_bits(self, 0)
+    }
+}
+
+impl<const N: usize> LamportMessage for &[u8; N] {
+    fn into_message_bits(self) -> Vec<bool> {
+        bytes_to_bits(self, 0)
+    }
+}
+
 // ========== Main Lamport Implementation ==========
 
 /// Main Lamport signature scheme implementation
@@ -1110,21 +1164,28 @@ impl Lamport {
         self.sign_message(&message_bits, private_key)
     }
 
-    /// Verify a Lamport signature
+    /// Verify a Lamport signature.
+    ///
+    /// Accepts any message type that implements [`LamportMessage`]:
+    /// - `bool` — verify a single-bit message
+    /// - `&[bool]` / `&Vec<bool>` / `&[bool; N]` — verify a multi-bit message
+    /// - `&[u8]` / `&Vec<u8>` / `&[u8; N]` — verify a byte message (converted to bits internally)
     ///
     /// # Arguments
-    /// * `message_bits` - The message that was allegedly signed (as boolean array)
+    /// * `message` - The message that was allegedly signed
     /// * `signature` - The signature to verify
     /// * `public_key` - The public key to verify against
     ///
     /// # Returns
-    /// True if the signature is valid, false otherwise
-    pub fn verify_signature(
+    /// `Ok(true)` if the signature is valid, `Ok(false)` otherwise
+    pub fn verify_signature<M: LamportMessage>(
         &self,
-        message_bits: &[bool],
+        message: M,
         signature: &LamportSignature,
         public_key: &LamportPublicKey,
     ) -> Result<bool, LamportError> {
+        let message_bits = message.into_message_bits();
+
         if message_bits.len() != signature.message_bit_length() {
             return Err(LamportError::MessageLengthMismatch(
                 message_bits.len(),
@@ -1158,50 +1219,6 @@ impl Lamport {
         }
 
         Ok(true)
-    }
-
-    /// Verify a Lamport signature from message bytes
-    ///
-    /// This is a convenience wrapper around `verify_signature` that converts bytes to bits.
-    /// For most use cases (e.g., verifying SHA256 digests), this is the preferred method.
-    ///
-    /// # Arguments
-    /// * `message_bytes` - The message that was allegedly signed
-    /// * `signature` - The signature to verify
-    /// * `public_key` - The public key to verify against
-    ///
-    /// # Returns
-    /// True if the signature is valid, false otherwise
-    pub fn verify_signature_bytes(
-        &self,
-        message_bytes: &[u8],
-        signature: &LamportSignature,
-        public_key: &LamportPublicKey,
-    ) -> Result<bool, LamportError> {
-        let message_bits = bytes_to_bits(message_bytes, 0);
-        self.verify_signature(&message_bits, signature, public_key)
-    }
-
-    /// Verify a Lamport signature for a single bit
-    ///
-    /// This is a convenience wrapper around `verify_signature` for verifying individual bits.
-    /// Commonly used for garbled circuits where wire labels are verified bit by bit.
-    ///
-    /// # Arguments
-    /// * `message_bit` - The single bit that was allegedly signed
-    /// * `signature` - The signature to verify
-    /// * `public_key` - The public key to verify against (must have message_bit_length = 1)
-    ///
-    /// # Returns
-    /// True if the signature is valid, false otherwise
-    pub fn verify_signature_bit(
-        &self,
-        message_bit: bool,
-        signature: &LamportSignature,
-        public_key: &LamportPublicKey,
-    ) -> Result<bool, LamportError> {
-        let message_bits = [message_bit];
-        self.verify_signature(&message_bits, signature, public_key)
     }
 
     /// Helper function to generate a hash using HMAC for key derivation
@@ -1680,7 +1697,7 @@ mod tests {
             .unwrap();
 
         let is_valid = lamport
-            .verify_signature_bytes(&message_bytes, &signature, &public_key)
+            .verify_signature(&message_bytes, &signature, &public_key)
             .unwrap();
 
         assert!(is_valid);
@@ -1688,7 +1705,7 @@ mod tests {
         // Verify that wrong message fails
         let wrong_message = [1u8; 32];
         let is_valid = lamport
-            .verify_signature_bytes(&wrong_message, &signature, &public_key)
+            .verify_signature(&wrong_message, &signature, &public_key)
             .unwrap();
 
         assert!(!is_valid);
@@ -1711,12 +1728,12 @@ mod tests {
             .sign_message_bytes(message_bytes, &private_key)
             .unwrap();
 
-        // Verify bytes signature with bytes method
+        // Verify bytes signature with verify_signature (bytes)
         assert!(lamport
-            .verify_signature_bytes(message_bytes, &sig_bytes, &public_key)
+            .verify_signature(message_bytes, &sig_bytes, &public_key)
             .unwrap());
 
-        // Verify bytes signature with bits method (should also work)
+        // Verify bytes signature with verify_signature (bits) — should also work
         let message_bits = bytes_to_bits(message_bytes, 0);
         assert!(lamport
             .verify_signature(&message_bits, &sig_bytes, &public_key)
@@ -1748,7 +1765,7 @@ mod tests {
                 .unwrap();
 
             let is_valid = lamport
-                .verify_signature_bytes(&message_bytes, &signature, &public_key)
+                .verify_signature(&message_bytes, &signature, &public_key)
                 .unwrap();
 
             assert!(is_valid, "Failed for byte_length={}", byte_length);
@@ -1773,20 +1790,20 @@ mod tests {
 
         // Original message should verify
         assert!(lamport
-            .verify_signature_bytes(&message_bytes, &signature, &public_key)
+            .verify_signature(&message_bytes, &signature, &public_key)
             .unwrap());
 
         // Tampered message (single bit flip) should fail
         let mut tampered_message = message_bytes;
         tampered_message[0] = 0x43; // Change one byte
         assert!(!lamport
-            .verify_signature_bytes(&tampered_message, &signature, &public_key)
+            .verify_signature(&tampered_message, &signature, &public_key)
             .unwrap());
 
         // Completely different message should fail
         let different_message = [0xFFu8; 32];
         assert!(!lamport
-            .verify_signature_bytes(&different_message, &signature, &public_key)
+            .verify_signature(&different_message, &signature, &public_key)
             .unwrap());
     }
 
@@ -1804,10 +1821,10 @@ mod tests {
         // Test signing bit value 0
         let signature_0 = lamport.sign_message_bit(false, &private_key_bit0).unwrap();
         assert!(lamport
-            .verify_signature_bit(false, &signature_0, &public_key_bit0)
+            .verify_signature(false, &signature_0, &public_key_bit0)
             .unwrap());
         assert!(!lamport
-            .verify_signature_bit(true, &signature_0, &public_key_bit0)
+            .verify_signature(true, &signature_0, &public_key_bit0)
             .unwrap());
 
         // Generate another key for signing bit value 1
@@ -1819,10 +1836,10 @@ mod tests {
         // Test signing bit value 1
         let signature_1 = lamport.sign_message_bit(true, &private_key_bit1).unwrap();
         assert!(lamport
-            .verify_signature_bit(true, &signature_1, &public_key_bit1)
+            .verify_signature(true, &signature_1, &public_key_bit1)
             .unwrap());
         assert!(!lamport
-            .verify_signature_bit(false, &signature_1, &public_key_bit1)
+            .verify_signature(false, &signature_1, &public_key_bit1)
             .unwrap());
     }
 
@@ -1845,9 +1862,9 @@ mod tests {
             .verify_signature(&message_bits, &sig_bit, &public_key)
             .unwrap());
 
-        // Verify using bit method
+        // Verify using verify_signature with bool
         assert!(lamport
-            .verify_signature_bit(true, &sig_bit, &public_key)
+            .verify_signature(true, &sig_bit, &public_key)
             .unwrap());
     }
 
@@ -1882,12 +1899,12 @@ mod tests {
         // Verify each wire value
         for (i, &wire_value) in wire_values.iter().enumerate() {
             assert!(lamport
-                .verify_signature_bit(wire_value, &signatures[i], &pubkeys[i])
+                .verify_signature(wire_value, &signatures[i], &pubkeys[i])
                 .unwrap());
 
             // Verify that wrong bit value fails
             assert!(!lamport
-                .verify_signature_bit(!wire_value, &signatures[i], &pubkeys[i])
+                .verify_signature(!wire_value, &signatures[i], &pubkeys[i])
                 .unwrap());
         }
     }
@@ -1914,13 +1931,13 @@ mod tests {
             .unwrap();
 
         assert!(lamport
-            .verify_signature_bytes(&message_bytes, &signature, &public_key)
+            .verify_signature(&message_bytes, &signature, &public_key)
             .unwrap());
 
         // Test with wrong message
         let wrong_message = [0x43u8; 20];
         assert!(!lamport
-            .verify_signature_bytes(&wrong_message, &signature, &public_key)
+            .verify_signature(&wrong_message, &signature, &public_key)
             .unwrap());
     }
 
@@ -1944,13 +1961,13 @@ mod tests {
             .unwrap();
 
         assert!(lamport
-            .verify_signature_bytes(&message_bytes, &signature, &public_key)
+            .verify_signature(&message_bytes, &signature, &public_key)
             .unwrap());
 
         // Test with wrong message
         let wrong_message = [0xBBu8; 32];
         assert!(!lamport
-            .verify_signature_bytes(&wrong_message, &signature, &public_key)
+            .verify_signature(&wrong_message, &signature, &public_key)
             .unwrap());
     }
 
@@ -2363,7 +2380,7 @@ mod tests {
 
         // This should fail because hash types don't match
         let is_valid = lamport
-            .verify_signature_bytes(&message_bytes, &signature, &public_key_hash160)
+            .verify_signature(&message_bytes, &signature, &public_key_hash160)
             .unwrap();
         assert!(!is_valid);
     }
@@ -2603,7 +2620,7 @@ mod tests {
             .sign_message_bytes(&message_bytes, &private_key)
             .unwrap();
         assert!(lamport
-            .verify_signature_bytes(&message_bytes, &signature, &public_key)
+            .verify_signature(&message_bytes, &signature, &public_key)
             .unwrap());
     }
 

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -265,7 +265,7 @@ pub struct LamportPublicKey {
     public_key_0s: Vec<LamportHash>,
     public_key_1s: Vec<LamportHash>,
     hash_type: LamportType,
-    extra_data: Option<ExtraData>,
+    extra_data: Option<ExtraData>, // TODO extract bit length from extra data to here, is a needed data?
 }
 
 impl LamportPublicKey {
@@ -519,13 +519,14 @@ pub struct LamportPrivateKey {
     private_key_1s: Vec<LamportHash>,
     hash_type: LamportType,
     message_bit_length: usize,
+    // TODO move to extra data? - in winternitz was only for public key, but as lamport is stored,.. rethink where i need that and why optional for this case
     derivation_index: u32, // TODO what to use if the key was imported and not derived?
 }
 
 impl LamportPrivateKey {
     pub fn new(
         hash_type: LamportType,
-        message_bit_length: usize,
+        message_bit_length: usize, // TODO needed?
         derivation_index: u32,
     ) -> Self {
         // Note: Validation is performed in generate_private_key and from_bytes methods
@@ -888,7 +889,7 @@ impl Lamport {
     /// Sign a message using a Lamport private key
     ///
     /// # Arguments
-    /// * `message_bits` - The message to sign as a vector of bits (boolean array)
+    /// * `message_bits` - The message to sign as a vector of bits (boolean array 0=false, 1=true)
     /// * `private_key` - The private key to use for signing
     ///
     /// # Returns
@@ -955,7 +956,7 @@ impl Lamport {
     /// Commonly used for garbled circuits where wire labels need to be signed bit by bit.
     ///
     /// # Arguments
-    /// * `message_bit` - The single bit to sign
+    /// * `message_bit` - The single bit to sign - bool representing a bit false = 0, true = 1
     /// * `private_key` - The private key to use for signing (must have message_bit_length = 1)
     ///
     /// # Returns
@@ -966,7 +967,7 @@ impl Lamport {
     /// Reusing a Lamport private key allows attackers to forge signatures.
     pub fn sign_message_bit(
         &self,
-        message_bit: bool,
+        message_bit: bool, // bool representing a bit false = 0, true = 1
         private_key: &LamportPrivateKey,
     ) -> Result<LamportSignature, LamportError> {
         let message_bits = [message_bit];

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 
 use bitcoin::hashes::{ripemd160, sha256, Hash, HashEngine, Hmac, HmacEngine};
 use serde::{Deserialize, Serialize};
-// use zeroize::Zeroize; // TODO, keep ?
+use zeroize::Zeroize;
 
 use crate::errors::LamportError;
 
@@ -80,12 +80,11 @@ pub struct LamportHash {
     hash: Vec<u8>,
 }
 
-// TODO do we want zeroize private key on drop? or left responsibility to the caller?
-// impl Zeroize for LamportHash {
-//     fn zeroize(&mut self) {
-//         self.hash.zeroize();
-//     }
-// }
+impl Zeroize for LamportHash {
+    fn zeroize(&mut self) {
+        self.hash.zeroize();
+    }
+}
 
 impl LamportHash {
     pub fn new(hash: Vec<u8>) -> Self {
@@ -673,7 +672,11 @@ impl LamportPrivateKey {
         Ok((hashes_0s?, hashes_1s?))
     }
 
-    // TODO to_hashes_string do we want this, its a secret ?
+    pub fn to_hashes_string(&self) -> (Vec<String>, Vec<String>) {
+        let hashes_0s = self.private_key_0s.iter().map(|hash| hash.to_hex()).collect();
+        let hashes_1s = self.private_key_1s.iter().map(|hash| hash.to_hex()).collect();
+        (hashes_0s, hashes_1s)
+    }
 
     pub fn len(&self) -> usize {
         self.private_key_0s.len()
@@ -736,18 +739,17 @@ impl LamportPrivateKey {
     }
 }
 
-// TODO do we want zeroize private key on drop? or left responsibility to the caller?
-// impl Drop for LamportPrivateKey {
-//     fn drop(&mut self) {
-//         // Zeroize the private keys on drop
-//         for hash in self.private_key_0s.iter_mut() {
-//             hash.hash.zeroize();
-//         }
-//         for hash in self.private_key_1s.iter_mut() {
-//             hash.hash.zeroize();
-//         }
-//     }
-// }
+impl Drop for LamportPrivateKey {
+    fn drop(&mut self) {
+        // Zeroize the private keys on drop
+        for hash in self.private_key_0s.iter_mut() {
+            hash.hash.zeroize();
+        }
+        for hash in self.private_key_1s.iter_mut() {
+            hash.hash.zeroize();
+        }
+    }
+}
 
 /// Main Lamport signature scheme implementation
 #[derive(Default)]

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -2757,4 +2757,226 @@ mod tests {
         );
         assert!(result.is_err());
     }
+
+    // ========== Serde Full Serialization Tests ==========
+
+    #[test]
+    fn test_serde_full_serialization_private_key() {
+        // Generate a private key with all attributes
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret_for_serde";
+        let hash_type = LamportType::SHA256;
+        let message_bit_length = 256;
+        let derivation_index: u32 = 42;
+
+        let mut private_key = lamport.generate_private_key(
+            master_secret,
+            hash_type,
+            message_bit_length,
+            derivation_index,
+        )
+        .unwrap();
+
+        // Mark as spent to test that field
+        private_key.mark_spent();
+
+        // Serialize to JSON string (easy to save to file)
+        let serialized = serde_json::to_string(&private_key).unwrap();
+        println!("Serialized private key: {} bytes", serialized.len());
+
+        // Deserialize back
+        let deserialized: LamportPrivateKey = serde_json::from_str(&serialized).unwrap();
+
+        // Verify all attributes are preserved
+        assert_eq!(deserialized.hash_type(), hash_type);
+        assert_eq!(deserialized.message_bit_length(), message_bit_length);
+        assert_eq!(deserialized.derivation_index(), Some(derivation_index));
+        assert_eq!(deserialized.spent(), true);
+        assert_eq!(deserialized.imported(), false);
+
+        // Verify the key material is identical
+        assert_eq!(deserialized.to_bytes(), private_key.to_bytes());
+
+        // Also test pretty JSON format
+        let pretty_json = serde_json::to_string_pretty(&private_key).unwrap();
+        println!("Pretty JSON (first 200 chars):\n{}", &pretty_json[..200.min(pretty_json.len())]);
+    }
+
+    #[test]
+    fn test_serde_full_serialization_public_key() {
+        // Generate a public key with all attributes
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret_public";
+        let hash_type = LamportType::RIPEMD160;
+        let message_bit_length = 160;
+        let derivation_index: u32 = 123;
+
+        let public_key = lamport.generate_public_key(
+            master_secret,
+            hash_type,
+            message_bit_length,
+            derivation_index,
+        )
+        .unwrap();
+
+        // Serialize to JSON string
+        let serialized = serde_json::to_string(&public_key).unwrap();
+        println!("Serialized public key: {} bytes", serialized.len());
+
+        // Deserialize back
+        let deserialized: LamportPublicKey = serde_json::from_str(&serialized).unwrap();
+
+        // Verify all attributes are preserved
+        assert_eq!(deserialized.hash_type(), hash_type);
+        assert_eq!(deserialized.message_bit_length().unwrap(), message_bit_length);
+        assert_eq!(deserialized.derivation_index(), Some(derivation_index));
+        assert_eq!(deserialized.imported(), false);
+
+        // Verify the key material is identical
+        assert_eq!(deserialized.to_bytes(), public_key.to_bytes());
+    }
+
+    #[test]
+    fn test_serde_json_compact_vs_pretty() {
+        // Test JSON compact vs pretty printing
+        let lamport = Lamport::new();
+        let master_secret = b"test_json_formats";
+        let hash_type = LamportType::HASH256;
+        let message_bit_length = 256;
+        let derivation_index: u32 = 999;
+
+        let private_key = lamport.generate_private_key(
+            master_secret,
+            hash_type,
+            message_bit_length,
+            derivation_index,
+        )
+        .unwrap();
+
+        // Serialize to compact JSON
+        let compact_json = serde_json::to_string(&private_key).unwrap();
+        println!("Compact JSON: {} bytes", compact_json.len());
+
+        // Serialize to pretty JSON
+        let pretty_json = serde_json::to_string_pretty(&private_key).unwrap();
+        println!("Pretty JSON: {} bytes", pretty_json.len());
+
+        // Compare with to_bytes() (which only includes key material)
+        let key_bytes_only = private_key.to_bytes();
+        println!("to_bytes() only: {} bytes", key_bytes_only.len());
+        println!("JSON overhead: {} bytes", compact_json.len() - key_bytes_only.len());
+
+        // Deserialize from both formats
+        let from_compact: LamportPrivateKey = serde_json::from_str(&compact_json).unwrap();
+        let from_pretty: LamportPrivateKey = serde_json::from_str(&pretty_json).unwrap();
+
+        // Verify everything matches
+        assert_eq!(from_compact.hash_type(), private_key.hash_type());
+        assert_eq!(from_compact.message_bit_length(), private_key.message_bit_length());
+        assert_eq!(from_compact.derivation_index(), private_key.derivation_index());
+        assert_eq!(from_compact.to_bytes(), private_key.to_bytes());
+
+        assert_eq!(from_pretty.hash_type(), private_key.hash_type());
+        assert_eq!(from_pretty.to_bytes(), private_key.to_bytes());
+    }
+
+    #[test]
+    fn test_serde_imported_key_serialization() {
+        // Test serialization of an imported key (imported=true, derivation_index=None)
+        let hash_type = LamportType::SHA256;
+        let message_bit_length = 256;
+
+        // Create key bytes
+        let key_bytes = vec![0u8; 2 * message_bit_length * hash_type.hash_size()];
+
+        let private_key = LamportPrivateKey::from_bytes(
+            &key_bytes,
+            message_bit_length,
+            hash_type,
+            None, // No derivation index for imported key
+            true, // imported = true
+        )
+        .unwrap();
+
+        // Serialize and deserialize
+        let serialized = serde_json::to_string(&private_key).unwrap();
+        let deserialized: LamportPrivateKey = serde_json::from_str(&serialized).unwrap();
+
+        // Verify imported flag and None derivation_index are preserved
+        assert_eq!(deserialized.imported(), true);
+        assert_eq!(deserialized.derivation_index(), None);
+        assert_eq!(deserialized.hash_type(), hash_type);
+    }
+
+    #[test]
+    fn test_serde_file_persistence_simulation() {
+        // Simulate saving to file and loading
+        use std::collections::HashMap;
+
+        let lamport = Lamport::new();
+        let master_secret = b"file_persistence_test";
+        let hash_type = LamportType::SHA256;
+
+        // Generate multiple keys
+        let mut key_storage: HashMap<u32, String> = HashMap::new();
+
+        for idx in 0..5u32 {
+            let private_key = lamport.generate_private_key(
+                master_secret,
+                hash_type,
+                256,
+                idx,
+            )
+            .unwrap();
+
+            // "Save to file" (serialize to string)
+            let serialized = serde_json::to_string(&private_key).unwrap();
+            key_storage.insert(idx, serialized);
+        }
+
+        // "Load from file" (deserialize from string)
+        for idx in 0..5u32 {
+            let serialized = key_storage.get(&idx).unwrap();
+            let loaded_key: LamportPrivateKey = serde_json::from_str(serialized).unwrap();
+
+            assert_eq!(loaded_key.derivation_index(), Some(idx));
+            assert_eq!(loaded_key.hash_type(), hash_type);
+            assert_eq!(loaded_key.message_bit_length(), 256);
+            assert_eq!(loaded_key.imported(), false);
+        }
+
+        println!("Successfully persisted and loaded {} keys", key_storage.len());
+    }
+
+    #[test]
+    fn test_serde_round_trip_all_hash_types() {
+        // Test serialization works for all hash types
+        let lamport = Lamport::new();
+        let master_secret = b"all_hash_types_test";
+        let hash_types = vec![
+            LamportType::SHA256,
+            LamportType::RIPEMD160,
+            LamportType::HASH160,
+            LamportType::HASH256,
+        ];
+
+        for hash_type in hash_types {
+            let message_bit_length = hash_type.hash_size() * 8;
+            let private_key = lamport.generate_private_key(
+                master_secret,
+                hash_type,
+                message_bit_length,
+                0,
+            )
+            .unwrap();
+
+            // JSON serialization
+            let json_serialized = serde_json::to_string(&private_key).unwrap();
+            let json_deserialized: LamportPrivateKey = serde_json::from_str(&json_serialized).unwrap();
+            assert_eq!(json_deserialized.hash_type(), hash_type);
+            assert_eq!(json_deserialized.to_bytes(), private_key.to_bytes());
+            assert_eq!(json_deserialized.derivation_index(), Some(0));
+            assert_eq!(json_deserialized.message_bit_length(), message_bit_length);
+        }
+    }
 }

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -383,12 +383,12 @@ impl LamportPublicKey {
         extra_data: Option<ExtraData>,
     ) -> Result<Self, LamportError> {
         let hash_size = hash_type.hash_size();
-        let expected_length = message_bit_length * hash_size * 2;
+        let expected_length = 2 * message_bit_length * hash_size;
 
         if bytes_0s_then_1s.len() != expected_length {
-            return Err(LamportError::InvalidPublicKeyLength(
+            return Err(LamportError::InvalidKeyLength(
                 bytes_0s_then_1s.len(),
-                message_bit_length * hash_size * 2,
+                expected_length,
             ));
         }
 
@@ -423,14 +423,14 @@ impl LamportPublicKey {
         let expected_length = message_bit_length * hash_size;
 
         if bytes_0s.len() != expected_length {
-            return Err(LamportError::InvalidPublicKeyLength(
+            return Err(LamportError::InvalidKeyLength(
                 bytes_0s.len(),
                 expected_length,
             ));
         }
 
         if bytes_1s.len() != expected_length {
-            return Err(LamportError::InvalidPublicKeyLength(
+            return Err(LamportError::InvalidKeyLength(
                 bytes_1s.len(),
                 expected_length,
             ));
@@ -615,19 +615,12 @@ impl LamportPrivateKey {
     // returns all bytes for 0s concatenated with bytes for 1s, in the order of the message bits
     // we aware this is exporting only the keys without other attributes
     pub fn to_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
+        let (bytes_0s, bytes_1s) = self.to_bytes_splitted();
 
-        // Serialize 0s
-        for hash in self.private_key_0s.iter() {
-            bytes.extend_from_slice(&hash.hash);
-        }
-
-        // Serialize 1s
-        for hash in self.private_key_1s.iter() {
-            bytes.extend_from_slice(&hash.hash);
-        }
-
-        bytes
+        let mut combined = Vec::with_capacity(bytes_0s.len() + bytes_1s.len());
+        combined.extend_from_slice(&bytes_0s);
+        combined.extend_from_slice(&bytes_1s);
+        combined
     }
 
     // returns all bytes for 0s at 1st return param, bytes for 1s at the second, in the order of the message bits
@@ -656,40 +649,29 @@ impl LamportPrivateKey {
         derivation_index: Option<u32>,
         imported: bool,
     ) -> Result<Self, LamportError> {
-        validate_imported_and_derivation_consistency(imported, derivation_index)?;
-        validate_message_bit_length(message_bit_length)?;
-        validate_byte_length(bytes_0s_then_1s.len())?;
-
         let hash_size = hash_type.hash_size();
         let expected_length = 2 * message_bit_length * hash_size;
 
         if bytes_0s_then_1s.len() != expected_length {
-            return Err(LamportError::InvalidPublicKeyLength(
+            return Err(LamportError::InvalidKeyLength(
                 bytes_0s_then_1s.len(),
                 expected_length,
             ));
         }
 
-        let mut private_key =
-            LamportPrivateKey::new(hash_type, message_bit_length, derivation_index);
-        private_key.imported = imported;
-
         // Split bytes into 0s and 1s sections
-        let split_point = message_bit_length * hash_size;
+        let split_point = expected_length / 2;
         let bytes_0s = &bytes_0s_then_1s[..split_point];
         let bytes_1s = &bytes_0s_then_1s[split_point..];
 
-        for i in 0..message_bit_length {
-            let start = i * hash_size;
-            let end = start + hash_size;
-
-            let hash_0 = LamportHash::new(bytes_0s[start..end].to_vec());
-            let hash_1 = LamportHash::new(bytes_1s[start..end].to_vec());
-
-            private_key.push_key_pair(hash_0, hash_1)?;
-        }
-
-        Ok(private_key)
+        Self::from_bytes_splitted(
+            bytes_0s,
+            bytes_1s,
+            message_bit_length,
+            hash_type,
+            derivation_index,
+            imported,
+        )
     }
 
     pub fn from_bytes_splitted(
@@ -709,14 +691,14 @@ impl LamportPrivateKey {
         let expected_length = message_bit_length * hash_size;
 
         if bytes_0s.len() != expected_length {
-            return Err(LamportError::InvalidPublicKeyLength(
+            return Err(LamportError::InvalidKeyLength(
                 bytes_0s.len(),
                 expected_length,
             ));
         }
 
         if bytes_1s.len() != expected_length {
-            return Err(LamportError::InvalidPublicKeyLength(
+            return Err(LamportError::InvalidKeyLength(
                 bytes_1s.len(),
                 expected_length,
             ));
@@ -2025,7 +2007,7 @@ mod tests {
         let bytes = vec![0u8; 100]; // Wrong length
         let result = LamportPublicKey::from_bytes(&bytes, 256, LamportType::SHA256, false, None);
         assert!(result.is_err());
-        if let Err(LamportError::InvalidPublicKeyLength(got, expected)) = result {
+        if let Err(LamportError::InvalidKeyLength(got, expected)) = result {
             assert_eq!(got, 100);
             assert_eq!(expected, 2 * 256 * 32);
         } else {

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -382,38 +382,29 @@ impl LamportPublicKey {
         imported: bool,
         extra_data: Option<ExtraData>,
     ) -> Result<Self, LamportError> {
-        validate_message_bit_length(message_bit_length)?;
-        validate_byte_length(bytes_0s_then_1s.len())?;
-
         let hash_size = hash_type.hash_size();
-        let expected_length = 2 * message_bit_length * hash_size;
+        let expected_length = message_bit_length * hash_size * 2;
 
         if bytes_0s_then_1s.len() != expected_length {
             return Err(LamportError::InvalidPublicKeyLength(
                 bytes_0s_then_1s.len(),
-                expected_length,
+                message_bit_length * hash_size * 2,
             ));
         }
 
-        let mut public_key = LamportPublicKey::new(hash_type, extra_data);
-        public_key.imported = imported;
-
         // Split bytes into 0s and 1s sections
-        let split_point = message_bit_length * hash_size;
+        let split_point = expected_length / 2;
         let bytes_0s = &bytes_0s_then_1s[..split_point];
         let bytes_1s = &bytes_0s_then_1s[split_point..];
 
-        for i in 0..message_bit_length {
-            let start = i * hash_size;
-            let end = start + hash_size;
-
-            let hash_0 = LamportHash::new(bytes_0s[start..end].to_vec());
-            let hash_1 = LamportHash::new(bytes_1s[start..end].to_vec());
-
-            public_key.push_key_pair(hash_0, hash_1)?;
-        }
-
-        Ok(public_key)
+        Self::from_bytes_splitted(
+            bytes_0s,
+            bytes_1s,
+            message_bit_length,
+            hash_type,
+            imported,
+            extra_data,
+        )
     }
 
     pub fn from_bytes_splitted(

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -240,11 +240,11 @@ impl LamportSignature {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExtraData {
     message_bit_length: usize,
-    derivation_index: u32, // TODO what to use if the key was imported and not derived?
+    derivation_index: Option<u32>,
 }
 
 impl ExtraData {
-    pub fn new(message_bit_length: usize, derivation_index: u32) -> Self {
+    pub fn new(message_bit_length: usize, derivation_index: Option<u32>) -> Self {
         ExtraData {
             message_bit_length,
             derivation_index,
@@ -255,7 +255,7 @@ impl ExtraData {
         self.message_bit_length
     }
 
-    pub fn derivation_index(&self) -> u32 {
+    pub fn derivation_index(&self) -> Option<u32> {
         self.derivation_index
     }
 }
@@ -268,7 +268,8 @@ pub struct LamportPublicKey {
     public_key_0s: Vec<LamportHash>,
     public_key_1s: Vec<LamportHash>,
     hash_type: LamportType,
-    extra_data: Option<ExtraData>, // TODO extract bit length from extra data to here, is a needed data?
+    imported: bool, // if the key was imported or derived. imported = true, derive = false
+    extra_data: Option<ExtraData>,
 }
 
 impl LamportPublicKey {
@@ -281,6 +282,7 @@ impl LamportPublicKey {
             public_key_0s: Vec::new(),
             public_key_1s: Vec::new(),
             hash_type,
+            imported: false,
             extra_data,
         }
     }
@@ -348,6 +350,8 @@ impl LamportPublicKey {
         bytes_0s_then_1s: &[u8],
         message_bit_length: usize,
         hash_type: LamportType,
+        imported: bool,
+        extra_data: Option<ExtraData>,
     ) -> Result<Self, LamportError> {
         validate_message_bit_length(message_bit_length)?;
         validate_byte_length(bytes_0s_then_1s.len())?;
@@ -362,7 +366,8 @@ impl LamportPublicKey {
             ));
         }
 
-        let mut public_key = LamportPublicKey::new(hash_type, None);
+        let mut public_key = LamportPublicKey::new(hash_type, extra_data);
+        public_key.imported = imported;
 
         // Split bytes into 0s and 1s sections
         let split_point = message_bit_length * hash_size;
@@ -387,6 +392,8 @@ impl LamportPublicKey {
         bytes_1s: &[u8],
         message_bit_length: usize,
         hash_type: LamportType,
+        imported: bool,
+        extra_data: Option<ExtraData>,
     ) -> Result<Self, LamportError> {
         validate_message_bit_length(message_bit_length)?;
         let combined_length = bytes_0s.len().saturating_add(bytes_1s.len());
@@ -409,7 +416,8 @@ impl LamportPublicKey {
             ));
         }
 
-        let mut public_key = LamportPublicKey::new(hash_type, None);
+        let mut public_key = LamportPublicKey::new(hash_type, extra_data);
+        public_key.imported = imported;
 
         for i in 0..message_bit_length {
             let start = i * hash_size;
@@ -499,16 +507,14 @@ impl LamportPublicKey {
         Ok(message_bit_length)
     }
 
-    pub fn derivation_index(&self) -> Result<u32, LamportError> {
-        let derivation_index = self
-            .extra_data
+    pub fn derivation_index(&self) -> Option<u32> {
+        self.extra_data
             .as_ref()
-            .ok_or(LamportError::ExtraDataMissing(
-                "derivation_index".to_string(),
-            ))?
-            .derivation_index;
+            .and_then(|extra| extra.derivation_index)
+    }
 
-        Ok(derivation_index)
+    pub fn imported(&self) -> bool {
+        self.imported
     }
 
     fn public_key_0_at(&self, index: usize) -> Result<&LamportHash, LamportError> {
@@ -542,15 +548,16 @@ pub struct LamportPrivateKey {
     private_key_1s: Vec<LamportHash>,
     hash_type: LamportType,
     message_bit_length: usize,
-    // TODO move to extra data? - in winternitz was only for public key, but as lamport is stored,.. rethink where i need that and why optional for this case
-    derivation_index: u32, // TODO what to use if the key was imported and not derived?
+    imported: bool, // if the key was imported or derived. imported = true, derive = false
+    derivation_index: Option<u32>, // None if the key was imported and not derived
+    spent: bool, // if the key was already used to sign. once spent = true, it should never be used again for signing
 }
 
 impl LamportPrivateKey {
     pub fn new(
         hash_type: LamportType,
-        message_bit_length: usize, // TODO needed?
-        derivation_index: u32,
+        message_bit_length: usize,
+        derivation_index: Option<u32>,
     ) -> Self {
         // Note: Validation is performed in generate_private_key and from_bytes methods
         LamportPrivateKey {
@@ -558,7 +565,9 @@ impl LamportPrivateKey {
             private_key_1s: Vec::with_capacity(message_bit_length),
             hash_type,
             message_bit_length,
+            imported: false,
             derivation_index,
+            spent: false,
         }
     }
 
@@ -570,6 +579,9 @@ impl LamportPrivateKey {
                 self.derivation_index,
             )),
         );
+
+        // Copy the imported flag from private key to public key
+        public_key.imported = self.imported;
 
         for i in 0..self.private_key_0s.len() {
             let pub_0 = self.hash_type.hash(&self.private_key_0s[i].to_bytes());
@@ -619,7 +631,7 @@ impl LamportPrivateKey {
         bytes_0s_then_1s: &[u8],
         message_bit_length: usize,
         hash_type: LamportType,
-        derivation_index: u32,
+        derivation_index: Option<u32>,
     ) -> Result<Self, LamportError> {
         validate_message_bit_length(message_bit_length)?;
         validate_byte_length(bytes_0s_then_1s.len())?;
@@ -660,7 +672,7 @@ impl LamportPrivateKey {
         bytes_1s: &[u8],
         message_bit_length: usize,
         hash_type: LamportType,
-        derivation_index: u32,
+        derivation_index: Option<u32>,
     ) -> Result<Self, LamportError> {
         validate_message_bit_length(message_bit_length)?;
         let combined_length = bytes_0s.len().saturating_add(bytes_1s.len());
@@ -757,13 +769,30 @@ impl LamportPrivateKey {
         self.hash_type
     }
 
-    pub fn derivation_index(&self) -> u32 {
+    pub fn derivation_index(&self) -> Option<u32> {
         self.derivation_index
     }
 
     pub fn message_bit_length(&self) -> usize {
         self.message_bit_length
     }
+
+    pub fn imported(&self) -> bool {
+        self.imported
+    }
+
+    pub fn spent(&self) -> bool {
+        self.spent
+    }
+
+    pub fn mark_spent(&mut self) {
+        self.spent = true;
+    }
+
+    // TODO set necessary?
+    // pub fn set_imported(&mut self, imported: bool) {
+    //     self.imported = imported;
+    // }
 
     fn push_key_pair(
         &mut self,
@@ -855,7 +884,6 @@ impl Lamport {
         Lamport {}
     }
 
-    // TODO what deriv index to use if the key was imported and not derived?
     /// Generate a Lamport public key from a master secret
     ///
     /// # Arguments
@@ -883,8 +911,6 @@ impl Lamport {
         Ok(public_key)
     }
 
-    // TODO what deriv index to use if the key was imported and not derived?
-    // TODO do we know if it was already used when importing?
     /// Generate a Lamport private key from a master secret
     ///
     /// # Arguments
@@ -912,7 +938,7 @@ impl Lamport {
             .ok_or(LamportError::IndexOverflow)?;
 
         let mut private_key =
-            LamportPrivateKey::new(hash_type, message_bit_length, derivation_index);
+            LamportPrivateKey::new(hash_type, message_bit_length, Some(derivation_index));
 
         let hash_size = hash_type.hash_size();
 
@@ -1505,7 +1531,7 @@ mod tests {
 
         let bytes = public_key.to_bytes();
         let reconstructed =
-            LamportPublicKey::from_bytes(&bytes, message_bit_length, LamportType::SHA256).unwrap();
+            LamportPublicKey::from_bytes(&bytes, message_bit_length, LamportType::SHA256, false, Some(ExtraData::new(message_bit_length, Some(0)))).unwrap();
 
         assert_eq!(public_key.len(), reconstructed.len());
         assert_eq!(public_key.to_bytes(), reconstructed.to_bytes());
@@ -1910,7 +1936,7 @@ mod tests {
     #[test]
     fn test_error_invalid_public_key_length() {
         let bytes = vec![0u8; 100]; // Wrong length
-        let result = LamportPublicKey::from_bytes(&bytes, 256, LamportType::SHA256);
+        let result = LamportPublicKey::from_bytes(&bytes, 256, LamportType::SHA256, false, None);
         assert!(result.is_err());
         if let Err(LamportError::InvalidPublicKeyLength(got, expected)) = result {
             assert_eq!(got, 100);
@@ -1966,8 +1992,7 @@ mod tests {
         assert!(matches!(result, Err(LamportError::ExtraDataMissing(_))));
 
         let result = public_key.derivation_index();
-        assert!(result.is_err());
-        assert!(matches!(result, Err(LamportError::ExtraDataMissing(_))));
+        assert!(result.is_none());
     }
 
     #[test]
@@ -1996,7 +2021,7 @@ mod tests {
 
         let bytes = private_key.to_bytes();
         let reconstructed =
-            LamportPrivateKey::from_bytes(&bytes, message_bit_length, LamportType::SHA256, 0)
+            LamportPrivateKey::from_bytes(&bytes, message_bit_length, LamportType::SHA256, Some(0))
                 .unwrap();
 
         assert_eq!(private_key.len(), reconstructed.len());
@@ -2027,7 +2052,7 @@ mod tests {
             &bytes_1s,
             message_bit_length,
             LamportType::HASH160,
-            5,
+            Some(5),
         )
         .unwrap();
 
@@ -2055,6 +2080,8 @@ mod tests {
             &bytes_1s,
             message_bit_length,
             LamportType::SHA256,
+            false,
+            Some(ExtraData::new(message_bit_length, Some(7))),
         )
         .unwrap();
 
@@ -2207,10 +2234,10 @@ mod tests {
 
     #[test]
     fn test_extra_data_getters() {
-        let extra_data = ExtraData::new(256, 42);
+        let extra_data = ExtraData::new(256, Some(42));
 
         assert_eq!(extra_data.message_bit_length(), 256);
-        assert_eq!(extra_data.derivation_index(), 42);
+        assert_eq!(extra_data.derivation_index(), Some(42));
     }
 
     #[test]
@@ -2349,7 +2376,7 @@ mod tests {
         assert_eq!(private_key.len(), message_bit_length);
         assert!(!private_key.is_empty());
         assert_eq!(private_key.message_bit_length(), message_bit_length);
-        assert_eq!(private_key.derivation_index(), 7);
+        assert_eq!(private_key.derivation_index(), Some(7));
         assert_eq!(private_key.hash_type(), LamportType::HASH160);
     }
 
@@ -2552,6 +2579,8 @@ mod tests {
             &[0u8; 100],
             MAX_MESSAGE_BIT_LENGTH + 1,
             LamportType::SHA256,
+            false,
+            None,
         );
 
         assert!(result.is_err());
@@ -2572,7 +2601,7 @@ mod tests {
 
         // Try with a message_bit_length that would require more bytes than MAX
         let result =
-            LamportPublicKey::from_bytes(&large_vec, MAX_MESSAGE_BIT_LENGTH, LamportType::SHA256);
+            LamportPublicKey::from_bytes(&large_vec, MAX_MESSAGE_BIT_LENGTH, LamportType::SHA256, false, None);
 
         // Should fail because bytes length (1000) doesn't match expected (MAX_MESSAGE_BIT_LENGTH * 32 * 2)
         // but more importantly, it validates limits before trying to process
@@ -2586,7 +2615,7 @@ mod tests {
             &[0u8; 100],
             MAX_MESSAGE_BIT_LENGTH + 1,
             LamportType::SHA256,
-            0,
+            Some(0),
         );
 
         assert!(result.is_err());
@@ -2630,6 +2659,8 @@ mod tests {
             &bytes_1s,
             MAX_MESSAGE_BIT_LENGTH + 1,
             LamportType::SHA256,
+            false,
+            None,
         );
         assert!(result.is_err());
 
@@ -2639,7 +2670,7 @@ mod tests {
             &bytes_1s,
             MAX_MESSAGE_BIT_LENGTH + 1,
             LamportType::SHA256,
-            0,
+            Some(0),
         );
         assert!(result.is_err());
     }

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -636,7 +636,9 @@ impl LamportPrivateKey {
         message_bit_length: usize,
         hash_type: LamportType,
         derivation_index: Option<u32>,
+        imported: bool,
     ) -> Result<Self, LamportError> {
+        validate_imported_and_derivation_consistency(imported, derivation_index)?;
         validate_message_bit_length(message_bit_length)?;
         validate_byte_length(bytes_0s_then_1s.len())?;
 
@@ -652,6 +654,7 @@ impl LamportPrivateKey {
 
         let mut private_key =
             LamportPrivateKey::new(hash_type, message_bit_length, derivation_index);
+        private_key.imported = imported;
 
         // Split bytes into 0s and 1s sections
         let split_point = message_bit_length * hash_size;
@@ -677,7 +680,9 @@ impl LamportPrivateKey {
         message_bit_length: usize,
         hash_type: LamportType,
         derivation_index: Option<u32>,
+        imported: bool,
     ) -> Result<Self, LamportError> {
+        validate_imported_and_derivation_consistency(imported, derivation_index)?;
         validate_message_bit_length(message_bit_length)?;
         let combined_length = bytes_0s.len().saturating_add(bytes_1s.len());
         validate_byte_length(combined_length)?;
@@ -701,6 +706,7 @@ impl LamportPrivateKey {
 
         let mut private_key =
             LamportPrivateKey::new(hash_type, message_bit_length, derivation_index);
+        private_key.imported = imported;
 
         for i in 0..message_bit_length {
             let start = i * hash_size;
@@ -868,6 +874,25 @@ fn validate_byte_length(byte_length: usize) -> Result<(), LamportError> {
             byte_length,
             MAX_KEY_SIGNATURE_BYTE_LENGTH,
         ));
+    }
+    Ok(())
+}
+
+/// Validates consistency between imported flag and derivation_index:
+/// - Imported keys must have derivation_index = None
+/// - Derived keys must have a derivation_index value
+fn validate_imported_and_derivation_consistency(
+    imported: bool,
+    derivation_index: Option<u32>,
+) -> Result<(), LamportError> {
+    if imported {
+        if let Some(index) = derivation_index {
+            return Err(LamportError::ImportedKeyWithDerivationIndex(index));
+        }
+    } else {
+        if derivation_index.is_none() {
+            return Err(LamportError::DerivedKeyWithoutDerivationIndex);
+        }
     }
     Ok(())
 }
@@ -2020,7 +2045,7 @@ mod tests {
 
         let bytes = private_key.to_bytes();
         let reconstructed =
-            LamportPrivateKey::from_bytes(&bytes, message_bit_length, LamportType::SHA256, Some(0))
+            LamportPrivateKey::from_bytes(&bytes, message_bit_length, LamportType::SHA256, Some(0), false)
                 .unwrap();
 
         assert_eq!(private_key.len(), reconstructed.len());
@@ -2052,6 +2077,7 @@ mod tests {
             message_bit_length,
             LamportType::HASH160,
             Some(5),
+            false,
         )
         .unwrap();
 
@@ -2615,6 +2641,7 @@ mod tests {
             MAX_MESSAGE_BIT_LENGTH + 1,
             LamportType::SHA256,
             Some(0),
+            false,
         );
 
         assert!(result.is_err());
@@ -2670,6 +2697,7 @@ mod tests {
             MAX_MESSAGE_BIT_LENGTH + 1,
             LamportType::SHA256,
             Some(0),
+            false,
         );
         assert!(result.is_err());
     }

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -1076,10 +1076,15 @@ impl Lamport {
         Ok(private_key)
     }
 
-    /// Sign a message using a Lamport private key
+    /// Sign a message using a Lamport private key.
+    ///
+    /// Accepts any message type that implements [`LamportMessage`]:
+    /// - `bool` — sign a single-bit message
+    /// - `&[bool]` / `&Vec<bool>` / `&[bool; N]` — sign a multi-bit message
+    /// - `&[u8]` / `&Vec<u8>` / `&[u8; N]` — sign a byte message (converted to bits internally)
     ///
     /// # Arguments
-    /// * `message_bits` - The message to sign as a vector of bits (boolean array 0=false, 1=true)
+    /// * `message` - The message to sign
     /// * `private_key` - The private key to use for signing
     ///
     /// # Returns
@@ -1088,11 +1093,13 @@ impl Lamport {
     /// # Security Critical
     /// After calling this function, the private key MUST be marked as used and never reused.
     /// Reusing a Lamport private key allows attackers to forge signatures.
-    pub fn sign_message(
+    pub fn sign_message<M: LamportMessage>(
         &self,
-        message_bits: &[bool],
+        message: M,
         private_key: &LamportPrivateKey,
     ) -> Result<LamportSignature, LamportError> {
+        let message_bits = message.into_message_bits();
+
         if message_bits.len() != private_key.message_bit_length() {
             return Err(LamportError::MessageLengthMismatch(
                 message_bits.len(),
@@ -1114,54 +1121,6 @@ impl Lamport {
         }
 
         Ok(signature)
-    }
-
-    /// Sign a message from bytes using a Lamport private key
-    ///
-    /// This is a convenience wrapper around `sign_message` that converts bytes to bits.
-    /// For most use cases (e.g., signing SHA256 digests), this is the preferred method.
-    ///
-    /// # Arguments
-    /// * `message_bytes` - The message to sign as bytes
-    /// * `private_key` - The private key to use for signing
-    ///
-    /// # Returns
-    /// The signature containing the revealed private key fragments
-    ///
-    /// # Security Critical
-    /// After calling this function, the private key MUST be marked as used and never reused.
-    /// Reusing a Lamport private key allows attackers to forge signatures.
-    pub fn sign_message_bytes(
-        &self,
-        message_bytes: &[u8],
-        private_key: &LamportPrivateKey,
-    ) -> Result<LamportSignature, LamportError> {
-        let message_bits = bytes_to_bits(message_bytes, 0);
-        self.sign_message(&message_bits, private_key)
-    }
-
-    /// Sign a single bit using a Lamport private key
-    ///
-    /// This is a convenience wrapper around `sign_message` for signing individual bits.
-    /// Commonly used for garbled circuits where wire labels need to be signed bit by bit.
-    ///
-    /// # Arguments
-    /// * `message_bit` - The single bit to sign - bool representing a bit false = 0, true = 1
-    /// * `private_key` - The private key to use for signing (must have message_bit_length = 1)
-    ///
-    /// # Returns
-    /// The signature containing the revealed private key fragment
-    ///
-    /// # Security Critical
-    /// After calling this function, the private key MUST be marked as used and never reused.
-    /// Reusing a Lamport private key allows attackers to forge signatures.
-    pub fn sign_message_bit(
-        &self,
-        message_bit: bool, // bool representing a bit false = 0, true = 1
-        private_key: &LamportPrivateKey,
-    ) -> Result<LamportSignature, LamportError> {
-        let message_bits = [message_bit];
-        self.sign_message(&message_bits, private_key)
     }
 
     /// Verify a Lamport signature.
@@ -1693,7 +1652,7 @@ mod tests {
         let public_key = private_key.public_key().unwrap();
 
         let signature = lamport
-            .sign_message_bytes(&message_bytes, &private_key)
+            .sign_message(&message_bytes, &private_key)
             .unwrap();
 
         let is_valid = lamport
@@ -1725,7 +1684,7 @@ mod tests {
 
         // Sign with bytes method
         let sig_bytes = lamport
-            .sign_message_bytes(message_bytes, &private_key)
+            .sign_message(message_bytes, &private_key)
             .unwrap();
 
         // Verify bytes signature with verify_signature (bytes)
@@ -1761,7 +1720,7 @@ mod tests {
             let public_key = private_key.public_key().unwrap();
 
             let signature = lamport
-                .sign_message_bytes(&message_bytes, &private_key)
+                .sign_message(&message_bytes, &private_key)
                 .unwrap();
 
             let is_valid = lamport
@@ -1785,7 +1744,7 @@ mod tests {
         let public_key = private_key.public_key().unwrap();
 
         let signature = lamport
-            .sign_message_bytes(&message_bytes, &private_key)
+            .sign_message(&message_bytes, &private_key)
             .unwrap();
 
         // Original message should verify
@@ -1819,7 +1778,7 @@ mod tests {
         let public_key_bit0 = private_key_bit0.public_key().unwrap();
 
         // Test signing bit value 0
-        let signature_0 = lamport.sign_message_bit(false, &private_key_bit0).unwrap();
+        let signature_0 = lamport.sign_message(false, &private_key_bit0).unwrap();
         assert!(lamport
             .verify_signature(false, &signature_0, &public_key_bit0)
             .unwrap());
@@ -1834,7 +1793,7 @@ mod tests {
         let public_key_bit1 = private_key_bit1.public_key().unwrap();
 
         // Test signing bit value 1
-        let signature_1 = lamport.sign_message_bit(true, &private_key_bit1).unwrap();
+        let signature_1 = lamport.sign_message(true, &private_key_bit1).unwrap();
         assert!(lamport
             .verify_signature(true, &signature_1, &public_key_bit1)
             .unwrap());
@@ -1854,7 +1813,7 @@ mod tests {
         let public_key = private_key.public_key().unwrap();
 
         // Sign using bit method
-        let sig_bit = lamport.sign_message_bit(true, &private_key).unwrap();
+        let sig_bit = lamport.sign_message(true, &private_key).unwrap();
 
         // Verify using array method
         let message_bits = [true];
@@ -1892,7 +1851,7 @@ mod tests {
         // Sign each wire value
         let mut signatures = Vec::new();
         for (i, &wire_value) in wire_values.iter().enumerate() {
-            let sig = lamport.sign_message_bit(wire_value, &keys[i]).unwrap();
+            let sig = lamport.sign_message(wire_value, &keys[i]).unwrap();
             signatures.push(sig);
         }
 
@@ -1927,7 +1886,7 @@ mod tests {
 
         let message_bytes = [0x42u8; 20]; // Sign a 20-byte message
         let signature = lamport
-            .sign_message_bytes(&message_bytes, &private_key)
+            .sign_message(&message_bytes, &private_key)
             .unwrap();
 
         assert!(lamport
@@ -1957,7 +1916,7 @@ mod tests {
 
         let message_bytes = [0xAAu8; 32]; // Sign a 32-byte message
         let signature = lamport
-            .sign_message_bytes(&message_bytes, &private_key)
+            .sign_message(&message_bytes, &private_key)
             .unwrap();
 
         assert!(lamport
@@ -2193,7 +2152,7 @@ mod tests {
 
         let message_bytes = [0x42u8; 16]; // 128 bits
         let signature = lamport
-            .sign_message_bytes(&message_bytes, &private_key)
+            .sign_message(&message_bytes, &private_key)
             .unwrap();
 
         let bytes = signature.to_bytes();
@@ -2259,7 +2218,7 @@ mod tests {
 
         let message_bytes = [0x42u8; 2]; // 16 bits
         let signature = lamport
-            .sign_message_bytes(&message_bytes, &private_key)
+            .sign_message(&message_bytes, &private_key)
             .unwrap();
 
         let result = signature.to_array_hashes();
@@ -2293,7 +2252,7 @@ mod tests {
         // Test signature to_hashes
         let message_bytes = [0x42u8; 1];
         let signature = lamport
-            .sign_message_bytes(&message_bytes, &private_key)
+            .sign_message(&message_bytes, &private_key)
             .unwrap();
         let sig_hashes = signature.to_hashes();
         assert_eq!(sig_hashes.len(), message_bit_length);
@@ -2369,7 +2328,7 @@ mod tests {
             .unwrap();
         let message_bytes = [0x42u8; 16];
         let signature = lamport
-            .sign_message_bytes(&message_bytes, &private_key_sha256)
+            .sign_message(&message_bytes, &private_key_sha256)
             .unwrap();
 
         // Try to verify with a HASH160 public key (different hash type)
@@ -2447,7 +2406,7 @@ mod tests {
 
         let message_bytes = [0x42u8; 8];
         let signature = lamport
-            .sign_message_bytes(&message_bytes, &private_key)
+            .sign_message(&message_bytes, &private_key)
             .unwrap();
 
         assert_eq!(signature.len(), message_bit_length);
@@ -2617,7 +2576,7 @@ mod tests {
         // Sign and verify a large message
         let message_bytes = vec![0x42u8; 128]; // 1024 bits
         let signature = lamport
-            .sign_message_bytes(&message_bytes, &private_key)
+            .sign_message(&message_bytes, &private_key)
             .unwrap();
         assert!(lamport
             .verify_signature(&message_bytes, &signature, &public_key)

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -937,7 +937,7 @@ fn validate_imported_and_derivation_consistency(
 /// - `bool` — single-bit message
 /// - `&[bool]` / `&Vec<bool>` / `&[bool; N]` — multi-bit messages
 /// - `&[u8]` / `&Vec<u8>` / `&[u8; N]` — byte messages (bits derived MSB-first)
-pub trait LamportMessage {
+pub trait LamportMessage: Clone {
     fn into_message_bits(self) -> Vec<bool>;
 }
 

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -828,8 +828,6 @@ impl Lamport {
     }
 
 
-    // TODO Sign and Verify by message bits, and also by messages bytes, as for many cases using SHA256 as hash function will imply that the message is really the message digest, obtained by hashing also the message, so it willl be 32 exact bytes
-
     /// Sign a message using a Lamport private key
     ///
     /// # Arguments
@@ -868,6 +866,54 @@ impl Lamport {
         }
 
         Ok(signature)
+    }
+
+    /// Sign a message from bytes using a Lamport private key
+    ///
+    /// This is a convenience wrapper around `sign_message` that converts bytes to bits.
+    /// For most use cases (e.g., signing SHA256 digests), this is the preferred method.
+    ///
+    /// # Arguments
+    /// * `message_bytes` - The message to sign as bytes
+    /// * `private_key` - The private key to use for signing
+    ///
+    /// # Returns
+    /// The signature containing the revealed private key fragments
+    ///
+    /// # Security Critical
+    /// After calling this function, the private key MUST be marked as used and never reused.
+    /// Reusing a Lamport private key allows attackers to forge signatures.
+    pub fn sign_message_bytes(
+        &self,
+        message_bytes: &[u8],
+        private_key: &LamportPrivateKey,
+    ) -> Result<LamportSignature, LamportError> {
+        let message_bits = bytes_to_bits(message_bytes, 0);
+        self.sign_message(&message_bits, private_key)
+    }
+
+    /// Sign a single bit using a Lamport private key
+    ///
+    /// This is a convenience wrapper around `sign_message` for signing individual bits.
+    /// Commonly used for garbled circuits where wire labels need to be signed bit by bit.
+    ///
+    /// # Arguments
+    /// * `message_bit` - The single bit to sign
+    /// * `private_key` - The private key to use for signing (must have message_bit_length = 1)
+    ///
+    /// # Returns
+    /// The signature containing the revealed private key fragment
+    ///
+    /// # Security Critical
+    /// After calling this function, the private key MUST be marked as used and never reused.
+    /// Reusing a Lamport private key allows attackers to forge signatures.
+    pub fn sign_message_bit(
+        &self,
+        message_bit: bool,
+        private_key: &LamportPrivateKey,
+    ) -> Result<LamportSignature, LamportError> {
+        let message_bits = [message_bit];
+        self.sign_message(&message_bits, private_key)
     }
 
     /// Verify a Lamport signature
@@ -918,6 +964,50 @@ impl Lamport {
         }
 
         Ok(true)
+    }
+
+    /// Verify a Lamport signature from message bytes
+    ///
+    /// This is a convenience wrapper around `verify_signature` that converts bytes to bits.
+    /// For most use cases (e.g., verifying SHA256 digests), this is the preferred method.
+    ///
+    /// # Arguments
+    /// * `message_bytes` - The message that was allegedly signed
+    /// * `signature` - The signature to verify
+    /// * `public_key` - The public key to verify against
+    ///
+    /// # Returns
+    /// True if the signature is valid, false otherwise
+    pub fn verify_signature_bytes(
+        &self,
+        message_bytes: &[u8],
+        signature: &LamportSignature,
+        public_key: &LamportPublicKey,
+    ) -> Result<bool, LamportError> {
+        let message_bits = bytes_to_bits(message_bytes, 0);
+        self.verify_signature(&message_bits, signature, public_key)
+    }
+
+    /// Verify a Lamport signature for a single bit
+    ///
+    /// This is a convenience wrapper around `verify_signature` for verifying individual bits.
+    /// Commonly used for garbled circuits where wire labels are verified bit by bit.
+    ///
+    /// # Arguments
+    /// * `message_bit` - The single bit that was allegedly signed
+    /// * `signature` - The signature to verify
+    /// * `public_key` - The public key to verify against (must have message_bit_length = 1)
+    ///
+    /// # Returns
+    /// True if the signature is valid, false otherwise
+    pub fn verify_signature_bit(
+        &self,
+        message_bit: bool,
+        signature: &LamportSignature,
+        public_key: &LamportPublicKey,
+    ) -> Result<bool, LamportError> {
+        let message_bits = [message_bit];
+        self.verify_signature(&message_bits, signature, public_key)
     }
 
     /// Helper function to generate a hash using HMAC for key derivation
@@ -1347,5 +1437,201 @@ mod tests {
             .unwrap();
 
         assert!(is_valid);
+    }
+
+    #[test]
+    fn test_lamport_sign_and_verify_bytes() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret_12345678901234567890";
+
+        // Sign a 32-byte SHA256 digest (common use case)
+        let message_bytes = [0u8; 32]; // Example: a zero-filled digest
+        let message_bit_length = 256;
+
+        let private_key = lamport
+            .generate_private_key(master_secret, LamportType::SHA256, message_bit_length, 0)
+            .unwrap();
+        let public_key = private_key.public_key().unwrap();
+
+        let signature = lamport.sign_message_bytes(&message_bytes, &private_key).unwrap();
+
+        let is_valid = lamport
+            .verify_signature_bytes(&message_bytes, &signature, &public_key)
+            .unwrap();
+
+        assert!(is_valid);
+
+        // Verify that wrong message fails
+        let wrong_message = [1u8; 32];
+        let is_valid = lamport
+            .verify_signature_bytes(&wrong_message, &signature, &public_key)
+            .unwrap();
+
+        assert!(!is_valid);
+    }
+
+    #[test]
+    fn test_bytes_and_bits_methods_equivalent() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret_12345678901234567890";
+        let message_bytes = b"Test message";
+        let message_bit_length = message_bytes.len() * 8;
+
+        let private_key = lamport
+            .generate_private_key(master_secret, LamportType::SHA256, message_bit_length, 0)
+            .unwrap();
+        let public_key = private_key.public_key().unwrap();
+
+        // Sign with bytes method
+        let sig_bytes = lamport.sign_message_bytes(message_bytes, &private_key).unwrap();
+
+        // Verify bytes signature with bytes method
+        assert!(lamport.verify_signature_bytes(message_bytes, &sig_bytes, &public_key).unwrap());
+
+        // Verify bytes signature with bits method (should also work)
+        let message_bits = bytes_to_bits(message_bytes, 0);
+        assert!(lamport.verify_signature(&message_bits, &sig_bytes, &public_key).unwrap());
+    }
+
+    #[test]
+    fn test_sign_bytes_various_lengths() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret_12345678901234567890";
+
+        // Test with various message lengths
+        for byte_length in [1, 8, 16, 20, 32] {
+            let message_bytes = vec![0xABu8; byte_length];
+            let message_bit_length = byte_length * 8;
+
+            let private_key = lamport
+                .generate_private_key(master_secret, LamportType::SHA256, message_bit_length, byte_length as u32)
+                .unwrap();
+            let public_key = private_key.public_key().unwrap();
+
+            let signature = lamport.sign_message_bytes(&message_bytes, &private_key).unwrap();
+
+            let is_valid = lamport
+                .verify_signature_bytes(&message_bytes, &signature, &public_key)
+                .unwrap();
+
+            assert!(is_valid, "Failed for byte_length={}", byte_length);
+        }
+    }
+
+    #[test]
+    fn test_verify_bytes_detects_tampering() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret_12345678901234567890";
+        let message_bytes = [0x42u8; 32];
+        let message_bit_length = 256;
+
+        let private_key = lamport
+            .generate_private_key(master_secret, LamportType::SHA256, message_bit_length, 0)
+            .unwrap();
+        let public_key = private_key.public_key().unwrap();
+
+        let signature = lamport.sign_message_bytes(&message_bytes, &private_key).unwrap();
+
+        // Original message should verify
+        assert!(lamport.verify_signature_bytes(&message_bytes, &signature, &public_key).unwrap());
+
+        // Tampered message (single bit flip) should fail
+        let mut tampered_message = message_bytes;
+        tampered_message[0] = 0x43; // Change one byte
+        assert!(!lamport.verify_signature_bytes(&tampered_message, &signature, &public_key).unwrap());
+
+        // Completely different message should fail
+        let different_message = [0xFFu8; 32];
+        assert!(!lamport.verify_signature_bytes(&different_message, &signature, &public_key).unwrap());
+    }
+
+    #[test]
+    fn test_sign_and_verify_single_bit() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret_12345678901234567890";
+
+        // Generate a key for signing single bits (message_bit_length = 1)
+        let private_key_bit0 = lamport
+            .generate_private_key(master_secret, LamportType::SHA256, 1, 0)
+            .unwrap();
+        let public_key_bit0 = private_key_bit0.public_key().unwrap();
+
+        // Test signing bit value 0
+        let signature_0 = lamport.sign_message_bit(false, &private_key_bit0).unwrap();
+        assert!(lamport.verify_signature_bit(false, &signature_0, &public_key_bit0).unwrap());
+        assert!(!lamport.verify_signature_bit(true, &signature_0, &public_key_bit0).unwrap());
+
+        // Generate another key for signing bit value 1
+        let private_key_bit1 = lamport
+            .generate_private_key(master_secret, LamportType::SHA256, 1, 1)
+            .unwrap();
+        let public_key_bit1 = private_key_bit1.public_key().unwrap();
+
+        // Test signing bit value 1
+        let signature_1 = lamport.sign_message_bit(true, &private_key_bit1).unwrap();
+        assert!(lamport.verify_signature_bit(true, &signature_1, &public_key_bit1).unwrap());
+        assert!(!lamport.verify_signature_bit(false, &signature_1, &public_key_bit1).unwrap());
+    }
+
+    #[test]
+    fn test_bit_methods_equivalent_to_array_methods() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret_12345678901234567890";
+
+        let private_key = lamport
+            .generate_private_key(master_secret, LamportType::SHA256, 1, 0)
+            .unwrap();
+        let public_key = private_key.public_key().unwrap();
+
+        // Sign using bit method
+        let sig_bit = lamport.sign_message_bit(true, &private_key).unwrap();
+
+        // Verify using array method
+        let message_bits = [true];
+        assert!(lamport.verify_signature(&message_bits, &sig_bit, &public_key).unwrap());
+
+        // Verify using bit method
+        assert!(lamport.verify_signature_bit(true, &sig_bit, &public_key).unwrap());
+    }
+
+    #[test]
+    fn test_garbled_circuit_wire_label_scenario() {
+        // Simulate a garbled circuit scenario where we need to sign individual wire labels
+        let lamport = Lamport::new();
+        let master_secret = b"garbled_circuit_master_secret_123456789";
+
+        // Generate keys for multiple wire labels (each is 1 bit)
+        let mut keys = Vec::new();
+        let mut pubkeys = Vec::new();
+        for i in 0..5 {
+            let key = lamport
+                .generate_private_key(master_secret, LamportType::SHA256, 1, i)
+                .unwrap();
+            let pubkey = key.public_key().unwrap();
+            keys.push(key);
+            pubkeys.push(pubkey);
+        }
+
+        // Simulate wire values: [true, false, true, true, false]
+        let wire_values = [true, false, true, true, false];
+
+        // Sign each wire value
+        let mut signatures = Vec::new();
+        for (i, &wire_value) in wire_values.iter().enumerate() {
+            let sig = lamport.sign_message_bit(wire_value, &keys[i]).unwrap();
+            signatures.push(sig);
+        }
+
+        // Verify each wire value
+        for (i, &wire_value) in wire_values.iter().enumerate() {
+            assert!(lamport
+                .verify_signature_bit(wire_value, &signatures[i], &pubkeys[i])
+                .unwrap());
+
+            // Verify that wrong bit value fails
+            assert!(!lamport
+                .verify_signature_bit(!wire_value, &signatures[i], &pubkeys[i])
+                .unwrap());
+        }
     }
 }

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -1127,59 +1127,76 @@ impl Lamport {
 
     /// Verify a Lamport signature.
     ///
-    /// Accepts any message type that implements [`LamportMessage`]:
-    /// - `bool` — verify a single-bit message
-    /// - `&[bool]` / `&Vec<bool>` / `&[bool; N]` — verify a multi-bit message
-    /// - `&[u8]` / `&Vec<u8>` / `&[u8; N]` — verify a byte message (converted to bits internally)
+    /// Accepts an optional message type that implements [`LamportMessage`]:
+    /// - `Some(bool)` — verify a single-bit message
+    /// - `Some(&[bool])` / `Some(&Vec<bool>)` / `Some(&[bool; N])` — verify a multi-bit message
+    /// - `Some(&[u8])` / `Some(&Vec<u8>)` / `Some(&[u8; N])` — verify a byte message (converted to bits internally)
+    /// - `None` — skip message comparison; only reconstruct and return the message bits derived from the signature
     ///
     /// # Arguments
-    /// * `message` - The message that was allegedly signed
+    /// * `message` - The message that was allegedly signed, or `None` to skip comparison
     /// * `signature` - The signature to verify
     /// * `public_key` - The public key to verify against
     ///
     /// # Returns
-    /// `Ok(true)` if the signature is valid, `Ok(false)` otherwise
+    /// `Ok((true, Some(bits)))` if the signature is valid, where `bits` is the reconstructed message bits.
+    /// `Ok((false, None))` if any revealed key does not hash to a valid public key entry.
+    /// When `message` is `None`, the signature is validated structurally (each revealed key must hash
+    /// to either the 0 or 1 public key), and the reconstructed message bits are returned without
+    /// comparing against an expected value.
     pub fn verify_signature<M: LamportMessage>(
         &self,
-        message: M,
+        message: Option<M>,
         signature: &LamportSignature,
         public_key: &LamportPublicKey,
-    ) -> Result<bool, LamportError> {
-        let message_bits = message.into_message_bits();
+    ) -> Result<(bool, Option<Vec<bool>>), LamportError> {
 
-        if message_bits.len() != signature.message_bit_length() {
-            return Err(LamportError::MessageLengthMismatch(
-                message_bits.len(),
-                signature.message_bit_length(),
-            ));
-        }
+        // validate only if the message was provided
+        if message.is_some() {
+            let message_bits = message.clone().unwrap().into_message_bits();
 
-        if message_bits.len() != public_key.len() {
-            return Err(LamportError::MessageLengthMismatch(
-                message_bits.len(),
-                public_key.len(),
-            ));
+            if message_bits.len() != signature.message_bit_length() {
+                return Err(LamportError::MessageLengthMismatch(
+                    message_bits.len(),
+                    signature.message_bit_length(),
+                ));
+            }
+
+            if message_bits.len() != public_key.len() {
+                return Err(LamportError::MessageLengthMismatch(
+                    message_bits.len(),
+                    public_key.len(),
+                ));
+            }
         }
 
         let hash_type = public_key.hash_type();
 
-        // For each bit, verify the revealed key hashes to the correct public key
-        for (i, &bit) in message_bits.iter().enumerate() {
+        let mut reconstructed_message: Vec<bool> = Vec::with_capacity(public_key.len());
+        // For each signature revealed key, compare revealed key hashes to the correct public key reconstructing the message
+        for i in 0..public_key.len() {
             let revealed_key = signature.revealed_key_at(i)?;
             let hash_of_revealed = hash_type.hash(&revealed_key.to_bytes());
 
-            let expected_public_key = if bit {
-                public_key.public_key_1_at(i)?
+            if hash_of_revealed == *public_key.public_key_0_at(i)? {
+                // bit is 0
+                reconstructed_message.push(false);
+            } else if hash_of_revealed == *public_key.public_key_1_at(i)? {
+                // bit is 1
+                reconstructed_message.push(true);
             } else {
-                public_key.public_key_0_at(i)?
-            };
-
-            if hash_of_revealed != *expected_public_key {
-                return Ok(false);
+                return Ok((false, None));
             }
         }
 
-        Ok(true)
+        // check only if the message was provided
+        if let Some(m) = message {
+            if reconstructed_message != m.into_message_bits() {
+                return Ok((false, None));
+            }
+        }
+
+        Ok((true, Some(reconstructed_message)))
     }
 
     /// Helper function to generate a hash using HMAC for key derivation
@@ -1527,8 +1544,8 @@ mod tests {
             .sign_message(&message_bits, &private_key_120)
             .unwrap();
 
-        let is_valid = lamport
-            .verify_signature(&message_bits, &signature, &public_key_120)
+        let (is_valid, _) = lamport
+            .verify_signature(Some(&message_bits), &signature, &public_key_120)
             .unwrap();
 
         assert!(is_valid);
@@ -1554,8 +1571,8 @@ mod tests {
         let wrong_message_bytes = b"Wrong message!!";
         let wrong_message_bits = bytes_to_bits(wrong_message_bytes, 0);
 
-        let is_valid = lamport
-            .verify_signature(&wrong_message_bits, &signature, &public_key)
+        let (is_valid, _) = lamport
+            .verify_signature(Some(&wrong_message_bits), &signature, &public_key)
             .unwrap();
 
         assert!(!is_valid);
@@ -1632,8 +1649,8 @@ mod tests {
             .sign_message(&message_bits, &private_key_120)
             .unwrap();
 
-        let is_valid = lamport
-            .verify_signature(&message_bits, &signature, &public_key_120)
+        let (is_valid, _) = lamport
+            .verify_signature(Some(&message_bits), &signature, &public_key_120)
             .unwrap();
 
         assert!(is_valid);
@@ -1655,16 +1672,16 @@ mod tests {
 
         let signature = lamport.sign_message(&message_bytes, &private_key).unwrap();
 
-        let is_valid = lamport
-            .verify_signature(&message_bytes, &signature, &public_key)
+        let (is_valid, _) = lamport
+            .verify_signature(Some(&message_bytes), &signature, &public_key)
             .unwrap();
 
         assert!(is_valid);
 
         // Verify that wrong message fails
         let wrong_message = [1u8; 32];
-        let is_valid = lamport
-            .verify_signature(&wrong_message, &signature, &public_key)
+        let (is_valid, _) = lamport
+            .verify_signature(Some(&wrong_message), &signature, &public_key)
             .unwrap();
 
         assert!(!is_valid);
@@ -1687,14 +1704,16 @@ mod tests {
 
         // Verify bytes signature with verify_signature (bytes)
         assert!(lamport
-            .verify_signature(message_bytes, &sig_bytes, &public_key)
-            .unwrap());
+            .verify_signature(Some(message_bytes), &sig_bytes, &public_key)
+            .unwrap()
+            .0);
 
         // Verify bytes signature with verify_signature (bits) — should also work
         let message_bits = bytes_to_bits(message_bytes, 0);
         assert!(lamport
-            .verify_signature(&message_bits, &sig_bytes, &public_key)
-            .unwrap());
+            .verify_signature(Some(&message_bits), &sig_bytes, &public_key)
+            .unwrap()
+            .0);
     }
 
     #[test]
@@ -1719,8 +1738,8 @@ mod tests {
 
             let signature = lamport.sign_message(&message_bytes, &private_key).unwrap();
 
-            let is_valid = lamport
-                .verify_signature(&message_bytes, &signature, &public_key)
+            let (is_valid, _) = lamport
+                .verify_signature(Some(&message_bytes), &signature, &public_key)
                 .unwrap();
 
             assert!(is_valid, "Failed for byte_length={}", byte_length);
@@ -1743,21 +1762,24 @@ mod tests {
 
         // Original message should verify
         assert!(lamport
-            .verify_signature(&message_bytes, &signature, &public_key)
-            .unwrap());
+            .verify_signature(Some(&message_bytes), &signature, &public_key)
+            .unwrap()
+            .0);
 
         // Tampered message (single bit flip) should fail
         let mut tampered_message = message_bytes;
         tampered_message[0] = 0x43; // Change one byte
         assert!(!lamport
-            .verify_signature(&tampered_message, &signature, &public_key)
-            .unwrap());
+            .verify_signature(Some(&tampered_message), &signature, &public_key)
+            .unwrap()
+            .0);
 
         // Completely different message should fail
         let different_message = [0xFFu8; 32];
         assert!(!lamport
-            .verify_signature(&different_message, &signature, &public_key)
-            .unwrap());
+            .verify_signature(Some(&different_message), &signature, &public_key)
+            .unwrap()
+            .0);
     }
 
     #[test]
@@ -1774,11 +1796,13 @@ mod tests {
         // Test signing bit value 0
         let signature_0 = lamport.sign_message(false, &private_key_bit0).unwrap();
         assert!(lamport
-            .verify_signature(false, &signature_0, &public_key_bit0)
-            .unwrap());
+            .verify_signature(Some(false), &signature_0, &public_key_bit0)
+            .unwrap()
+            .0);
         assert!(!lamport
-            .verify_signature(true, &signature_0, &public_key_bit0)
-            .unwrap());
+            .verify_signature(Some(true), &signature_0, &public_key_bit0)
+            .unwrap()
+            .0);
 
         // Generate another key for signing bit value 1
         let private_key_bit1 = lamport
@@ -1789,11 +1813,13 @@ mod tests {
         // Test signing bit value 1
         let signature_1 = lamport.sign_message(true, &private_key_bit1).unwrap();
         assert!(lamport
-            .verify_signature(true, &signature_1, &public_key_bit1)
-            .unwrap());
+            .verify_signature(Some(true), &signature_1, &public_key_bit1)
+            .unwrap()
+            .0);
         assert!(!lamport
-            .verify_signature(false, &signature_1, &public_key_bit1)
-            .unwrap());
+            .verify_signature(Some(false), &signature_1, &public_key_bit1)
+            .unwrap()
+            .0);
     }
 
     #[test]
@@ -1812,13 +1838,15 @@ mod tests {
         // Verify using array method
         let message_bits = [true];
         assert!(lamport
-            .verify_signature(&message_bits, &sig_bit, &public_key)
-            .unwrap());
+            .verify_signature(Some(&message_bits), &sig_bit, &public_key)
+            .unwrap()
+            .0);
 
         // Verify using verify_signature with bool
         assert!(lamport
-            .verify_signature(true, &sig_bit, &public_key)
-            .unwrap());
+            .verify_signature(Some(true), &sig_bit, &public_key)
+            .unwrap()
+            .0);
     }
 
     #[test]
@@ -1852,13 +1880,15 @@ mod tests {
         // Verify each wire value
         for (i, &wire_value) in wire_values.iter().enumerate() {
             assert!(lamport
-                .verify_signature(wire_value, &signatures[i], &pubkeys[i])
-                .unwrap());
+                .verify_signature(Some(wire_value), &signatures[i], &pubkeys[i])
+                .unwrap()
+                .0);
 
             // Verify that wrong bit value fails
             assert!(!lamport
-                .verify_signature(!wire_value, &signatures[i], &pubkeys[i])
-                .unwrap());
+                .verify_signature(Some(!wire_value), &signatures[i], &pubkeys[i])
+                .unwrap()
+                .0);
         }
     }
 
@@ -1882,14 +1912,16 @@ mod tests {
         let signature = lamport.sign_message(&message_bytes, &private_key).unwrap();
 
         assert!(lamport
-            .verify_signature(&message_bytes, &signature, &public_key)
-            .unwrap());
+            .verify_signature(Some(&message_bytes), &signature, &public_key)
+            .unwrap()
+            .0);
 
         // Test with wrong message
         let wrong_message = [0x43u8; 20];
         assert!(!lamport
-            .verify_signature(&wrong_message, &signature, &public_key)
-            .unwrap());
+            .verify_signature(Some(&wrong_message), &signature, &public_key)
+            .unwrap()
+            .0);
     }
 
     #[test]
@@ -1910,14 +1942,16 @@ mod tests {
         let signature = lamport.sign_message(&message_bytes, &private_key).unwrap();
 
         assert!(lamport
-            .verify_signature(&message_bytes, &signature, &public_key)
-            .unwrap());
+            .verify_signature(Some(&message_bytes), &signature, &public_key)
+            .unwrap()
+            .0);
 
         // Test with wrong message
         let wrong_message = [0xBBu8; 32];
         assert!(!lamport
-            .verify_signature(&wrong_message, &signature, &public_key)
-            .unwrap());
+            .verify_signature(Some(&wrong_message), &signature, &public_key)
+            .unwrap()
+            .0);
     }
 
     #[test]
@@ -2322,8 +2356,8 @@ mod tests {
         let public_key_hash160 = private_key_hash160.public_key().unwrap();
 
         // This should fail because hash types don't match
-        let is_valid = lamport
-            .verify_signature(&message_bytes, &signature, &public_key_hash160)
+        let (is_valid, _) = lamport
+            .verify_signature(Some(&message_bytes), &signature, &public_key_hash160)
             .unwrap();
         assert!(!is_valid);
     }
@@ -2575,8 +2609,9 @@ mod tests {
         let message_bytes = vec![0x42u8; 128]; // 1024 bits
         let signature = lamport.sign_message(&message_bytes, &private_key).unwrap();
         assert!(lamport
-            .verify_signature(&message_bytes, &signature, &public_key)
-            .unwrap());
+            .verify_signature(Some(&message_bytes), &signature, &public_key)
+            .unwrap()
+            .0);
     }
 
     // ========== DoS Protection Tests ==========

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -2681,7 +2681,7 @@ mod tests {
     fn test_dos_protection_public_key_from_bytes_excessive_bytes() {
         // Create a huge byte array that exceeds MAX_KEY_SIGNATURE_BYTE_LENGTH
         // We don't actually allocate it, just pass the length check
-        let large_vec = vec![0u8; 1000]; // Small allocation for the test
+        let large_vec = vec![0u8; (MAX_MESSAGE_BIT_LENGTH + 1) * 32 * 2]; // using sha256 size for the test
 
         // Try with a message_bit_length that would require more bytes than MAX
         let result = LamportPublicKey::from_bytes(
@@ -2701,7 +2701,7 @@ mod tests {
     fn test_dos_protection_private_key_from_bytes() {
         // Try to deserialize with excessive message_bit_length
         let result = LamportPrivateKey::from_bytes(
-            &[0u8; 100],
+            &[0u8; (MAX_MESSAGE_BIT_LENGTH + 1) * 32 * 2], // using sha256 size for the test
             MAX_MESSAGE_BIT_LENGTH + 1,
             LamportType::SHA256,
             Some(0),
@@ -2714,7 +2714,7 @@ mod tests {
                 assert_eq!(actual, MAX_MESSAGE_BIT_LENGTH + 1);
                 assert_eq!(max, MAX_MESSAGE_BIT_LENGTH);
             }
-            _ => panic!("Expected MessageBitLengthExceedsMax error"),
+            _ => panic!("Expected MessageBitLengthExceedsMax error - got {:?}", result),
         }
     }
 

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -3,7 +3,6 @@ use std::str::FromStr;
 
 use bitcoin::hashes::{ripemd160, sha256, Hash, HashEngine, Hmac, HmacEngine};
 use serde::{Deserialize, Serialize};
-use tracing::warn;
 // use zeroize::Zeroize; // TODO, keep ?
 
 use crate::errors::LamportError;
@@ -944,14 +943,36 @@ impl Lamport {
     }
 }
 
-// TODO padding should be added as a parameter, to know how many start 0s are not part of the message, for the funcs that call using exactly all the bits that fits in that bytes padding will be 0
 /// Convert a byte array to a bit array
 /// Each byte is expanded to 8 bits (MSB first)
-pub fn bytes_to_bits(bytes: &[u8]) -> Vec<bool> {
-    let mut bits = Vec::with_capacity(bytes.len() * 8);
+///
+/// # Arguments
+/// * `bytes` - The byte array to convert
+/// * `padding` - Number of leading bits to skip in the first byte (0-7)
+///
+/// # Returns
+/// A vector of bools representing the bits, skipping the first `padding` bits
+///
+/// # Example
+/// ```
+/// // bytes = [0b00010110], padding = 3
+/// // Result skips first 3 bits: [true, false, true, true, false] (the bits "10110")
+/// ```
+pub fn bytes_to_bits(bytes: &[u8], padding: usize) -> Vec<bool> {
+    if bytes.is_empty() {
+        return Vec::new();
+    }
+
+    let total_bits = bytes.len() * 8;
+    let mut bits = Vec::with_capacity(total_bits.saturating_sub(padding));
+    let mut bits_to_skip = padding;
 
     for byte in bytes {
         for bit_index in 0..8 {
+            if bits_to_skip > 0 {
+                bits_to_skip -= 1;
+                continue;
+            }
             let bit = (byte >> (7 - bit_index)) & 1;
             bits.push(bit == 1);
             // Example extracting bits from byte 0b10110011 (179 in decimal):
@@ -966,33 +987,64 @@ pub fn bytes_to_bits(bytes: &[u8]) -> Vec<bool> {
     bits
 }
 
-// TODO padding should be added as a return value, to know how many start 0s of the 1st byte are not part of the message, for the cases converting bits mutiple of 8 the padding will be 0
 /// Convert a bit array back to bytes
 /// Every 8 bits are combined into one byte (MSB first)
-pub fn bits_to_bytes(bits: &[bool]) -> Result<Vec<u8>, LamportError> {
-    if bits.len() % 8 != 0 {
-        return Err(LamportError::InvalidBitLength(bits.len()));
+///
+/// # Returns
+/// A tuple containing:
+/// * The byte vector
+/// * The padding value (number of leading zeros added to make bits fit into bytes)
+///
+/// # Example
+/// ```
+/// // bits = [true, false, true, true, false] (5 bits: "10110")
+/// // Padding = 3, result bytes = [0b00010110]
+/// // Returns: (vec![0b00010110], 3)
+/// ```
+pub fn bits_to_bytes(bits: &[bool]) -> Result<(Vec<u8>, usize), LamportError> {
+    if bits.is_empty() {
+        return Ok((Vec::new(), 0));
     }
 
-    let mut bytes = Vec::with_capacity(bits.len() / 8);
+    // Calculate padding needed: how many zeros to prepend to make length a multiple of 8
+    let padding = (8 - (bits.len() % 8)) % 8; // double % for the case 8 - 0 = 8 which should be 0 padding
+    let total_bits = padding + bits.len();
+    let mut bytes = Vec::with_capacity(total_bits / 8);
 
-    for chunk in bits.chunks(8) {
-        let mut byte = 0u8;
-        for (i, &bit) in chunk.iter().enumerate() {
-            if bit {
-                byte |= 1 << (7 - i); // bitwise or
-                // Example building byte 0b10110011 from bits [true, false, true, true, false, false, true, true]:
-                // i=0, bit=true:  1 << (7-0) = 1 << 7 = 0b10000000, byte |= 0b10000000 → byte = 0b10000000
-                // i=1, bit=false: skipped (if bit is false, don't set the bit)
-                // ...
-                // i=7, bit=true:  1 << (7-7) = 1 << 0 = 0b00000001, byte |= 0b00000001 → byte = 0b10110011
-                // Result: byte = 0b10110011 (179 in decimal)
-            }
+    let mut current_byte = 0u8;
+    let mut bit_position = 0;
+
+    // Add padding zeros
+    for _ in 0..padding {
+        // bit is 0, so we don't need to set it (current_byte starts as 0)
+        bit_position += 1;
+        if bit_position == 8 {
+            bytes.push(current_byte);
+            current_byte = 0;
+            bit_position = 0;
         }
-        bytes.push(byte);
     }
 
-    Ok(bytes)
+    // Add actual bits
+    for &bit in bits {
+        if bit {
+            current_byte |= 1 << (7 - bit_position);
+            // Example building byte 0b10110011 from bits [true, false, true, true, false, false, true, true]:
+            // bit_position=0, bit=true:  1 << (7-0) = 1 << 7 = 0b10000000, byte |= 0b10000000 → byte = 0b10000000
+            // bit_position=1, bit=false: skipped (if bit is false, don't set the bit)
+            // ...
+            // bit_position=7, bit=true:  1 << (7-7) = 1 << 0 = 0b00000001, byte |= 0b00000001 → byte = 0b10110011
+            // Result: byte = 0b10110011 (179 in decimal)
+        }
+        bit_position += 1;
+        if bit_position == 8 {
+            bytes.push(current_byte);
+            current_byte = 0;
+            bit_position = 0;
+        }
+    }
+
+    Ok((bytes, padding))
 }
 
 #[cfg(test)]
@@ -1000,15 +1052,172 @@ mod tests {
     use super::*;
 
 
-    // TODO in this test we assume we always have the hole byte filled with bits, we should create another tests, where we have 4 bits and padding, (filled with 0s at the begining) and 1 lonely bit with 7 0s as padding
     #[test]
     fn test_bytes_to_bits_and_back() {
+        // Test with no padding (full bytes)
         let original_bytes = vec![0b10110011, 0b01001100, 0xFF, 0x00];
-        let bits = bytes_to_bits(&original_bytes);
+        let bits = bytes_to_bits(&original_bytes, 0);
         assert_eq!(bits.len(), 32);
 
-        let reconstructed_bytes = bits_to_bytes(&bits).unwrap();
+        let (reconstructed_bytes, padding) = bits_to_bytes(&bits).unwrap();
+        assert_eq!(padding, 0);
         assert_eq!(original_bytes, reconstructed_bytes);
+    }
+
+    #[test]
+    fn test_bytes_to_bits_with_padding() {
+        // Test with 3 bits of padding
+        // bytes = [0b00010110], padding = 3
+        // Should skip first 3 bits and return the 5 bits: "10110"
+        let bytes = vec![0b00010110];
+        let bits = bytes_to_bits(&bytes, 3);
+        assert_eq!(bits.len(), 5);
+        assert_eq!(bits, vec![true, false, true, true, false]);
+
+        // Test with 7 bits of padding (1 bit remaining)
+        // bytes = [0b00000001], padding = 7
+        // Should return just 1 bit: "1"
+        let bytes = vec![0b00000001];
+        let bits = bytes_to_bits(&bytes, 7);
+        assert_eq!(bits.len(), 1);
+        assert_eq!(bits, vec![true]);
+
+        // Test with padding across multiple bytes
+        // bytes = [0b00001011, 0b01110011], padding = 4
+        // Should skip first 4 bits of first byte
+        let bytes = vec![0b00001011, 0b01110011];
+        let bits = bytes_to_bits(&bytes, 4);
+        assert_eq!(bits.len(), 12);
+        assert_eq!(
+            bits,
+            vec![true, false, true, true, false, true, true, true, false, false, true, true]
+        );
+    }
+
+    #[test]
+    fn test_bits_to_bytes_with_padding() {
+        // Test with 5 bits (requires 3 bits of padding)
+        // bits = [true, false, true, true, false] ("10110")
+        // Should produce bytes = [0b00010110], padding = 3
+        let bits = vec![true, false, true, true, false];
+        let (bytes, padding) = bits_to_bytes(&bits).unwrap();
+        assert_eq!(padding, 3);
+        assert_eq!(bytes, vec![0b00010110]);
+
+        // Test roundtrip
+        let reconstructed_bits = bytes_to_bits(&bytes, padding);
+        assert_eq!(bits, reconstructed_bits);
+
+        // Test with 1 bit (requires 7 bits of padding)
+        let bits = vec![true];
+        let (bytes, padding) = bits_to_bytes(&bits).unwrap();
+        assert_eq!(padding, 7);
+        assert_eq!(bytes, vec![0b00000001]);
+
+        // Test roundtrip
+        let reconstructed_bits = bytes_to_bits(&bytes, padding);
+        assert_eq!(bits, reconstructed_bits);
+
+        // Test with 0 padding (exact byte boundary)
+        let bits = vec![true, false, true, true, false, false, true, true];
+        let (bytes, padding) = bits_to_bytes(&bits).unwrap();
+        assert_eq!(padding, 0);
+        assert_eq!(bytes, vec![0b10110011]);
+    }
+
+    #[test]
+    fn test_bits_to_bytes_with_padding_zero() {
+        // Test with 0 padding (exact byte boundary - 8 bits)
+        let bits = vec![true, false, true, true, false, false, true, true];
+        let (bytes, padding) = bits_to_bytes(&bits).unwrap();
+        assert_eq!(padding, 0);
+        assert_eq!(bytes, vec![0b10110011]);
+
+        // Test roundtrip
+        let reconstructed_bits = bytes_to_bits(&bytes, padding);
+        assert_eq!(bits, reconstructed_bits);
+
+        // Test with 0 padding (exact byte boundary - 16 bits)
+        let bits = vec![
+            true, false, true, true, false, false, true, true,
+            false, true, false, false, true, true, false, false
+        ];
+        let (bytes, padding) = bits_to_bytes(&bits).unwrap();
+        assert_eq!(padding, 0);
+        assert_eq!(bytes, vec![0b10110011, 0b01001100]);
+
+        // Test roundtrip
+        let reconstructed_bits = bytes_to_bits(&bytes, padding);
+        assert_eq!(bits, reconstructed_bits);
+    }
+
+    #[test]
+    fn test_padding_greater_than_8() {
+        // Test with padding = 10 (spans across multiple bytes)
+        // bytes = [0x00, 0x05] = [0b00000000, 0b00000101]
+        // Skip first 10 bits: all 8 bits from first byte + 2 bits from second byte
+        // Remaining 6 bits from second byte: "000101"
+        let bytes = vec![0x00, 0x05];
+        let bits = bytes_to_bits(&bytes, 10);
+        assert_eq!(bits.len(), 6);
+        assert_eq!(bits, vec![false, false, false, true, false, true]);
+
+        // Test roundtrip
+        let (reconstructed_bytes, padding) = bits_to_bytes(&bits).unwrap();
+        assert_eq!(padding, 2); // 6 bits need 2 bits of padding to make 8
+        assert_eq!(reconstructed_bytes, vec![0b00000101]);
+        let final_bits = bytes_to_bits(&reconstructed_bytes, padding);
+        assert_eq!(bits, final_bits);
+
+        // Test with padding = 12 (1.5 bytes worth of padding)
+        // bytes = [0xFF, 0xFF, 0xFF] = 24 bits total
+        // Skip first 12 bits: all of first byte + half of second byte
+        // Remaining 12 bits: second half of 2nd byte + all of 3rd byte
+        let bytes = vec![0xFF, 0b11110101, 0xAA];
+        let bits = bytes_to_bits(&bytes, 12);
+        assert_eq!(bits.len(), 12);
+        assert_eq!(bits, vec![
+            false, true, false, true, // lower 4 bits of 0b11110101
+            true, false, true, false, true, false, true, false // 0xAA
+        ]);
+
+        // Test with padding = 15 (almost 2 bytes)
+        // bytes = [0x00, 0xFF, 0x01] = 24 bits total
+        // Skip first 15 bits
+        // Remaining 9 bits
+        let bytes = vec![0x00, 0xFF, 0x01];
+        let bits = bytes_to_bits(&bytes, 15);
+        assert_eq!(bits.len(), 9);
+        assert_eq!(bits, vec![true, false, false, false, false, false, false, false, true]);
+    }
+
+    #[test]
+    fn test_large_value_with_leading_zeros() {
+        // Simulate a u32 with value 5 (binary: 101)
+        // When serialized: [0x00, 0x00, 0x00, 0x05]
+        // That's 32 bits total, but only last 3 bits matter
+        // padding = 29 to skip the leading zeros
+        let value: u32 = 5;
+        let bytes = value.to_be_bytes();
+        let bits = bytes_to_bits(&bytes, 29);
+
+        assert_eq!(bits.len(), 3);
+        assert_eq!(bits, vec![true, false, true]); // "101" in binary
+
+        // Test roundtrip
+        let (reconstructed_bytes, padding) = bits_to_bytes(&bits).unwrap();
+        assert_eq!(padding, 5); // 3 bits need 5 bits padding to make 8
+        assert_eq!(reconstructed_bytes, vec![0b00000101]);
+        let final_bits = bytes_to_bits(&reconstructed_bytes, padding);
+        assert_eq!(bits, final_bits);
+
+        // Test with u16 value 7 (binary: 111)
+        let value: u16 = 7;
+        let bytes = value.to_be_bytes();
+        let bits = bytes_to_bits(&bytes, 13); // Skip 13 leading zeros
+
+        assert_eq!(bits.len(), 3);
+        assert_eq!(bits, vec![true, true, true]); // "111" in binary
     }
 
     #[test]
@@ -1035,11 +1244,11 @@ mod tests {
             .generate_private_key(master_secret, LamportType::SHA256, message_bit_length, 0)
             .unwrap();
 
-        let public_key = private_key.public_key().unwrap();
+        let _public_key = private_key.public_key().unwrap();
 
         // Create a test message
         let message_bytes = b"Hello, Lamport!"; // 15 bytes = 120 bits
-        let message_bits = bytes_to_bits(message_bytes);
+        let message_bits = bytes_to_bits(message_bytes, 0);
 
         // For this test, we need a key with the right bit length
         let private_key_120 = lamport
@@ -1068,13 +1277,13 @@ mod tests {
         let public_key = private_key.public_key().unwrap();
 
         let message_bytes = b"Hello, Lamport!";
-        let message_bits = bytes_to_bits(message_bytes);
+        let message_bits = bytes_to_bits(message_bytes, 0);
 
         let signature = lamport.sign_message(&message_bits, &private_key).unwrap();
 
         // Try to verify with a different message
         let wrong_message_bytes = b"Wrong message!!";
-        let wrong_message_bits = bytes_to_bits(wrong_message_bytes);
+        let wrong_message_bits = bytes_to_bits(wrong_message_bytes, 0);
 
         let is_valid = lamport
             .verify_signature(&wrong_message_bits, &signature, &public_key)
@@ -1124,7 +1333,7 @@ mod tests {
 
         // Create a test message
         let message_bytes = b"Hello, HASH160!"; // 15 bytes = 120 bits
-        let message_bits = bytes_to_bits(message_bytes);
+        let message_bits = bytes_to_bits(message_bytes, 0);
 
         let private_key_120 = lamport
             .generate_private_key(master_secret, LamportType::HASH160, 120, 1)

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -110,7 +110,9 @@ impl FromStr for LamportType {
     fn from_str(input: &str) -> Result<LamportType, Self::Err> {
         match input.to_uppercase().as_str() {
             "SHA256" => Ok(LamportType::SHA256),
+            "RIPEMD160" => Ok(LamportType::RIPEMD160),
             "HASH160" => Ok(LamportType::HASH160),
+            "HASH256" => Ok(LamportType::HASH256),
             _ => Err(LamportError::InvalidLamportType(input.to_string())),
         }
     }
@@ -2461,9 +2463,25 @@ mod tests {
             LamportType::HASH160
         );
 
+        assert_eq!(
+            LamportType::from_str("RIPEMD160").unwrap(),
+            LamportType::RIPEMD160
+        );
+        assert_eq!(
+            LamportType::from_str("ripemd160").unwrap(),
+            LamportType::RIPEMD160
+        );
+
+        assert_eq!(
+            LamportType::from_str("HASH256").unwrap(),
+            LamportType::HASH256
+        );
+        assert_eq!(
+            LamportType::from_str("hash256").unwrap(),
+            LamportType::HASH256
+        );
+
         // Test invalid types
-        assert!(LamportType::from_str("RIPEMD160").is_err());
-        assert!(LamportType::from_str("HASH256").is_err());
         assert!(LamportType::from_str("MD5").is_err());
         assert!(LamportType::from_str("").is_err());
     }

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -1143,7 +1143,6 @@ impl Lamport {
         signature: &LamportSignature,
         public_key: &LamportPublicKey,
     ) -> Result<(bool, Option<Vec<bool>>), LamportError> {
-
         // validate only if the message was provided
         if message.is_some() {
             let message_bits = message.clone().unwrap().into_message_bits();
@@ -1696,17 +1695,21 @@ mod tests {
         let sig_bytes = lamport.sign_message(message_bytes, &private_key).unwrap();
 
         // Verify bytes signature with verify_signature (bytes)
-        assert!(lamport
-            .verify_signature(Some(message_bytes), &sig_bytes, &public_key)
-            .unwrap()
-            .0);
+        assert!(
+            lamport
+                .verify_signature(Some(message_bytes), &sig_bytes, &public_key)
+                .unwrap()
+                .0
+        );
 
         // Verify bytes signature with verify_signature (bits) — should also work
         let message_bits = bytes_to_bits(message_bytes, 0);
-        assert!(lamport
-            .verify_signature(Some(&message_bits), &sig_bytes, &public_key)
-            .unwrap()
-            .0);
+        assert!(
+            lamport
+                .verify_signature(Some(&message_bits), &sig_bytes, &public_key)
+                .unwrap()
+                .0
+        );
     }
 
     #[test]
@@ -1754,25 +1757,31 @@ mod tests {
         let signature = lamport.sign_message(&message_bytes, &private_key).unwrap();
 
         // Original message should verify
-        assert!(lamport
-            .verify_signature(Some(&message_bytes), &signature, &public_key)
-            .unwrap()
-            .0);
+        assert!(
+            lamport
+                .verify_signature(Some(&message_bytes), &signature, &public_key)
+                .unwrap()
+                .0
+        );
 
         // Tampered message (single bit flip) should fail
         let mut tampered_message = message_bytes;
         tampered_message[0] = 0x43; // Change one byte
-        assert!(!lamport
-            .verify_signature(Some(&tampered_message), &signature, &public_key)
-            .unwrap()
-            .0);
+        assert!(
+            !lamport
+                .verify_signature(Some(&tampered_message), &signature, &public_key)
+                .unwrap()
+                .0
+        );
 
         // Completely different message should fail
         let different_message = [0xFFu8; 32];
-        assert!(!lamport
-            .verify_signature(Some(&different_message), &signature, &public_key)
-            .unwrap()
-            .0);
+        assert!(
+            !lamport
+                .verify_signature(Some(&different_message), &signature, &public_key)
+                .unwrap()
+                .0
+        );
     }
 
     #[test]
@@ -1788,14 +1797,18 @@ mod tests {
 
         // Test signing bit value 0
         let signature_0 = lamport.sign_message(false, &private_key_bit0).unwrap();
-        assert!(lamport
-            .verify_signature(Some(false), &signature_0, &public_key_bit0)
-            .unwrap()
-            .0);
-        assert!(!lamport
-            .verify_signature(Some(true), &signature_0, &public_key_bit0)
-            .unwrap()
-            .0);
+        assert!(
+            lamport
+                .verify_signature(Some(false), &signature_0, &public_key_bit0)
+                .unwrap()
+                .0
+        );
+        assert!(
+            !lamport
+                .verify_signature(Some(true), &signature_0, &public_key_bit0)
+                .unwrap()
+                .0
+        );
 
         // Generate another key for signing bit value 1
         let private_key_bit1 = lamport
@@ -1805,14 +1818,18 @@ mod tests {
 
         // Test signing bit value 1
         let signature_1 = lamport.sign_message(true, &private_key_bit1).unwrap();
-        assert!(lamport
-            .verify_signature(Some(true), &signature_1, &public_key_bit1)
-            .unwrap()
-            .0);
-        assert!(!lamport
-            .verify_signature(Some(false), &signature_1, &public_key_bit1)
-            .unwrap()
-            .0);
+        assert!(
+            lamport
+                .verify_signature(Some(true), &signature_1, &public_key_bit1)
+                .unwrap()
+                .0
+        );
+        assert!(
+            !lamport
+                .verify_signature(Some(false), &signature_1, &public_key_bit1)
+                .unwrap()
+                .0
+        );
     }
 
     #[test]
@@ -1830,16 +1847,20 @@ mod tests {
 
         // Verify using array method
         let message_bits = [true];
-        assert!(lamport
-            .verify_signature(Some(&message_bits), &sig_bit, &public_key)
-            .unwrap()
-            .0);
+        assert!(
+            lamport
+                .verify_signature(Some(&message_bits), &sig_bit, &public_key)
+                .unwrap()
+                .0
+        );
 
         // Verify using verify_signature with bool
-        assert!(lamport
-            .verify_signature(Some(true), &sig_bit, &public_key)
-            .unwrap()
-            .0);
+        assert!(
+            lamport
+                .verify_signature(Some(true), &sig_bit, &public_key)
+                .unwrap()
+                .0
+        );
     }
 
     #[test]
@@ -1872,16 +1893,20 @@ mod tests {
 
         // Verify each wire value
         for (i, &wire_value) in wire_values.iter().enumerate() {
-            assert!(lamport
-                .verify_signature(Some(wire_value), &signatures[i], &pubkeys[i])
-                .unwrap()
-                .0);
+            assert!(
+                lamport
+                    .verify_signature(Some(wire_value), &signatures[i], &pubkeys[i])
+                    .unwrap()
+                    .0
+            );
 
             // Verify that wrong bit value fails
-            assert!(!lamport
-                .verify_signature(Some(!wire_value), &signatures[i], &pubkeys[i])
-                .unwrap()
-                .0);
+            assert!(
+                !lamport
+                    .verify_signature(Some(!wire_value), &signatures[i], &pubkeys[i])
+                    .unwrap()
+                    .0
+            );
         }
     }
 
@@ -1904,17 +1929,21 @@ mod tests {
         let message_bytes = [0x42u8; 20]; // Sign a 20-byte message
         let signature = lamport.sign_message(&message_bytes, &private_key).unwrap();
 
-        assert!(lamport
-            .verify_signature(Some(&message_bytes), &signature, &public_key)
-            .unwrap()
-            .0);
+        assert!(
+            lamport
+                .verify_signature(Some(&message_bytes), &signature, &public_key)
+                .unwrap()
+                .0
+        );
 
         // Test with wrong message
         let wrong_message = [0x43u8; 20];
-        assert!(!lamport
-            .verify_signature(Some(&wrong_message), &signature, &public_key)
-            .unwrap()
-            .0);
+        assert!(
+            !lamport
+                .verify_signature(Some(&wrong_message), &signature, &public_key)
+                .unwrap()
+                .0
+        );
     }
 
     #[test]
@@ -1934,17 +1963,21 @@ mod tests {
         let message_bytes = [0xAAu8; 32]; // Sign a 32-byte message
         let signature = lamport.sign_message(&message_bytes, &private_key).unwrap();
 
-        assert!(lamport
-            .verify_signature(Some(&message_bytes), &signature, &public_key)
-            .unwrap()
-            .0);
+        assert!(
+            lamport
+                .verify_signature(Some(&message_bytes), &signature, &public_key)
+                .unwrap()
+                .0
+        );
 
         // Test with wrong message
         let wrong_message = [0xBBu8; 32];
-        assert!(!lamport
-            .verify_signature(Some(&wrong_message), &signature, &public_key)
-            .unwrap()
-            .0);
+        assert!(
+            !lamport
+                .verify_signature(Some(&wrong_message), &signature, &public_key)
+                .unwrap()
+                .0
+        );
     }
 
     #[test]
@@ -2601,10 +2634,12 @@ mod tests {
         // Sign and verify a large message
         let message_bytes = vec![0x42u8; 128]; // 1024 bits
         let signature = lamport.sign_message(&message_bytes, &private_key).unwrap();
-        assert!(lamport
-            .verify_signature(Some(&message_bytes), &signature, &public_key)
-            .unwrap()
-            .0);
+        assert!(
+            lamport
+                .verify_signature(Some(&message_bytes), &signature, &public_key)
+                .unwrap()
+                .0
+        );
     }
 
     // ========== DoS Protection Tests ==========

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -789,11 +789,6 @@ impl LamportPrivateKey {
         self.spent = true;
     }
 
-    // TODO set necessary?
-    // pub fn set_imported(&mut self, imported: bool) {
-    //     self.imported = imported;
-    // }
-
     fn push_key_pair(
         &mut self,
         hash_0: LamportHash,

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -867,6 +867,15 @@ fn validate_message_bit_length(message_bit_length: usize) -> Result<(), LamportE
     Ok(())
 }
 
+/// Validates that we are 1 index below the overflow threshold for u32
+fn validate_following_derivation_index(derivation_index: u32) -> Result<(), LamportError> {
+    derivation_index
+        .checked_add(1)
+        .ok_or(LamportError::IndexOverflow)?;
+
+    Ok(())
+}
+
 /// Validates that byte length doesn't exceed the maximum to prevent DoS attacks
 fn validate_byte_length(byte_length: usize) -> Result<(), LamportError> {
     if byte_length > MAX_KEY_SIGNATURE_BYTE_LENGTH {
@@ -1010,10 +1019,7 @@ impl Lamport {
         derivation_index: u32,
     ) -> Result<LamportPrivateKey, LamportError> {
         validate_message_bit_length(message_bit_length)?;
-
-        derivation_index
-            .checked_add(1)
-            .ok_or(LamportError::IndexOverflow)?;
+        validate_following_derivation_index(derivation_index)?;
 
         let mut private_key =
             LamportPrivateKey::new(hash_type, message_bit_length, Some(derivation_index));
@@ -3000,5 +3006,22 @@ mod tests {
             assert_eq!(json_deserialized.derivation_index(), Some(0));
             assert_eq!(json_deserialized.message_bit_length(), message_bit_length);
         }
+    }
+
+    #[test]
+    fn test_lamport_derivation_index_correctness() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret";
+        let message_bit_length = 1024; // Large message
+
+        let derivation_index = 123;
+
+        let private_key = lamport
+            .generate_private_key(master_secret, LamportType::SHA256, message_bit_length, derivation_index)
+            .unwrap();
+        let public_key = private_key.public_key().unwrap();
+
+        assert_eq!(private_key.derivation_index(), Some(derivation_index));
+        assert_eq!(public_key.derivation_index(), Some(derivation_index));
     }
 }

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -1651,9 +1651,7 @@ mod tests {
             .unwrap();
         let public_key = private_key.public_key().unwrap();
 
-        let signature = lamport
-            .sign_message(&message_bytes, &private_key)
-            .unwrap();
+        let signature = lamport.sign_message(&message_bytes, &private_key).unwrap();
 
         let is_valid = lamport
             .verify_signature(&message_bytes, &signature, &public_key)
@@ -1683,9 +1681,7 @@ mod tests {
         let public_key = private_key.public_key().unwrap();
 
         // Sign with bytes method
-        let sig_bytes = lamport
-            .sign_message(message_bytes, &private_key)
-            .unwrap();
+        let sig_bytes = lamport.sign_message(message_bytes, &private_key).unwrap();
 
         // Verify bytes signature with verify_signature (bytes)
         assert!(lamport
@@ -1719,9 +1715,7 @@ mod tests {
                 .unwrap();
             let public_key = private_key.public_key().unwrap();
 
-            let signature = lamport
-                .sign_message(&message_bytes, &private_key)
-                .unwrap();
+            let signature = lamport.sign_message(&message_bytes, &private_key).unwrap();
 
             let is_valid = lamport
                 .verify_signature(&message_bytes, &signature, &public_key)
@@ -1743,9 +1737,7 @@ mod tests {
             .unwrap();
         let public_key = private_key.public_key().unwrap();
 
-        let signature = lamport
-            .sign_message(&message_bytes, &private_key)
-            .unwrap();
+        let signature = lamport.sign_message(&message_bytes, &private_key).unwrap();
 
         // Original message should verify
         assert!(lamport
@@ -1885,9 +1877,7 @@ mod tests {
         assert_eq!(public_key.hash_type(), LamportType::RIPEMD160);
 
         let message_bytes = [0x42u8; 20]; // Sign a 20-byte message
-        let signature = lamport
-            .sign_message(&message_bytes, &private_key)
-            .unwrap();
+        let signature = lamport.sign_message(&message_bytes, &private_key).unwrap();
 
         assert!(lamport
             .verify_signature(&message_bytes, &signature, &public_key)
@@ -1915,9 +1905,7 @@ mod tests {
         assert_eq!(public_key.hash_type(), LamportType::HASH256);
 
         let message_bytes = [0xAAu8; 32]; // Sign a 32-byte message
-        let signature = lamport
-            .sign_message(&message_bytes, &private_key)
-            .unwrap();
+        let signature = lamport.sign_message(&message_bytes, &private_key).unwrap();
 
         assert!(lamport
             .verify_signature(&message_bytes, &signature, &public_key)
@@ -2151,9 +2139,7 @@ mod tests {
             .unwrap();
 
         let message_bytes = [0x42u8; 16]; // 128 bits
-        let signature = lamport
-            .sign_message(&message_bytes, &private_key)
-            .unwrap();
+        let signature = lamport.sign_message(&message_bytes, &private_key).unwrap();
 
         let bytes = signature.to_bytes();
         let reconstructed =
@@ -2217,9 +2203,7 @@ mod tests {
             .unwrap();
 
         let message_bytes = [0x42u8; 2]; // 16 bits
-        let signature = lamport
-            .sign_message(&message_bytes, &private_key)
-            .unwrap();
+        let signature = lamport.sign_message(&message_bytes, &private_key).unwrap();
 
         let result = signature.to_array_hashes();
         assert!(result.is_ok());
@@ -2251,9 +2235,7 @@ mod tests {
 
         // Test signature to_hashes
         let message_bytes = [0x42u8; 1];
-        let signature = lamport
-            .sign_message(&message_bytes, &private_key)
-            .unwrap();
+        let signature = lamport.sign_message(&message_bytes, &private_key).unwrap();
         let sig_hashes = signature.to_hashes();
         assert_eq!(sig_hashes.len(), message_bit_length);
     }
@@ -2405,9 +2387,7 @@ mod tests {
             .unwrap();
 
         let message_bytes = [0x42u8; 8];
-        let signature = lamport
-            .sign_message(&message_bytes, &private_key)
-            .unwrap();
+        let signature = lamport.sign_message(&message_bytes, &private_key).unwrap();
 
         assert_eq!(signature.len(), message_bit_length);
         assert!(!signature.is_empty());
@@ -2575,9 +2555,7 @@ mod tests {
 
         // Sign and verify a large message
         let message_bytes = vec![0x42u8; 128]; // 1024 bits
-        let signature = lamport
-            .sign_message(&message_bytes, &private_key)
-            .unwrap();
+        let signature = lamport.sign_message(&message_bytes, &private_key).unwrap();
         assert!(lamport
             .verify_signature(&message_bytes, &signature, &public_key)
             .unwrap());
@@ -2745,13 +2723,14 @@ mod tests {
         let message_bit_length = 256;
         let derivation_index: u32 = 42;
 
-        let mut private_key = lamport.generate_private_key(
-            master_secret,
-            hash_type,
-            message_bit_length,
-            derivation_index,
-        )
-        .unwrap();
+        let mut private_key = lamport
+            .generate_private_key(
+                master_secret,
+                hash_type,
+                message_bit_length,
+                derivation_index,
+            )
+            .unwrap();
 
         // Mark as spent to test that field
         private_key.mark_spent();
@@ -2775,7 +2754,10 @@ mod tests {
 
         // Also test pretty JSON format
         let pretty_json = serde_json::to_string_pretty(&private_key).unwrap();
-        println!("Pretty JSON (first 200 chars):\n{}", &pretty_json[..200.min(pretty_json.len())]);
+        println!(
+            "Pretty JSON (first 200 chars):\n{}",
+            &pretty_json[..200.min(pretty_json.len())]
+        );
     }
 
     #[test]
@@ -2787,13 +2769,14 @@ mod tests {
         let message_bit_length = 160;
         let derivation_index: u32 = 123;
 
-        let public_key = lamport.generate_public_key(
-            master_secret,
-            hash_type,
-            message_bit_length,
-            derivation_index,
-        )
-        .unwrap();
+        let public_key = lamport
+            .generate_public_key(
+                master_secret,
+                hash_type,
+                message_bit_length,
+                derivation_index,
+            )
+            .unwrap();
 
         // Serialize to JSON string
         let serialized = serde_json::to_string(&public_key).unwrap();
@@ -2804,7 +2787,10 @@ mod tests {
 
         // Verify all attributes are preserved
         assert_eq!(deserialized.hash_type(), hash_type);
-        assert_eq!(deserialized.message_bit_length().unwrap(), message_bit_length);
+        assert_eq!(
+            deserialized.message_bit_length().unwrap(),
+            message_bit_length
+        );
         assert_eq!(deserialized.derivation_index(), Some(derivation_index));
         assert_eq!(deserialized.imported(), false);
 
@@ -2821,13 +2807,14 @@ mod tests {
         let message_bit_length = 256;
         let derivation_index: u32 = 999;
 
-        let private_key = lamport.generate_private_key(
-            master_secret,
-            hash_type,
-            message_bit_length,
-            derivation_index,
-        )
-        .unwrap();
+        let private_key = lamport
+            .generate_private_key(
+                master_secret,
+                hash_type,
+                message_bit_length,
+                derivation_index,
+            )
+            .unwrap();
 
         // Serialize to compact JSON
         let compact_json = serde_json::to_string(&private_key).unwrap();
@@ -2840,7 +2827,10 @@ mod tests {
         // Compare with to_bytes() (which only includes key material)
         let key_bytes_only = private_key.to_bytes();
         println!("to_bytes() only: {} bytes", key_bytes_only.len());
-        println!("JSON overhead: {} bytes", compact_json.len() - key_bytes_only.len());
+        println!(
+            "JSON overhead: {} bytes",
+            compact_json.len() - key_bytes_only.len()
+        );
 
         // Deserialize from both formats
         let from_compact: LamportPrivateKey = serde_json::from_str(&compact_json).unwrap();
@@ -2848,8 +2838,14 @@ mod tests {
 
         // Verify everything matches
         assert_eq!(from_compact.hash_type(), private_key.hash_type());
-        assert_eq!(from_compact.message_bit_length(), private_key.message_bit_length());
-        assert_eq!(from_compact.derivation_index(), private_key.derivation_index());
+        assert_eq!(
+            from_compact.message_bit_length(),
+            private_key.message_bit_length()
+        );
+        assert_eq!(
+            from_compact.derivation_index(),
+            private_key.derivation_index()
+        );
         assert_eq!(from_compact.to_bytes(), private_key.to_bytes());
 
         assert_eq!(from_pretty.hash_type(), private_key.hash_type());
@@ -2897,13 +2893,9 @@ mod tests {
         let mut key_storage: HashMap<u32, String> = HashMap::new();
 
         for idx in 0..5u32 {
-            let private_key = lamport.generate_private_key(
-                master_secret,
-                hash_type,
-                256,
-                idx,
-            )
-            .unwrap();
+            let private_key = lamport
+                .generate_private_key(master_secret, hash_type, 256, idx)
+                .unwrap();
 
             // "Save to file" (serialize to string)
             let serialized = serde_json::to_string(&private_key).unwrap();
@@ -2921,7 +2913,10 @@ mod tests {
             assert_eq!(loaded_key.imported(), false);
         }
 
-        println!("Successfully persisted and loaded {} keys", key_storage.len());
+        println!(
+            "Successfully persisted and loaded {} keys",
+            key_storage.len()
+        );
     }
 
     #[test]
@@ -2938,17 +2933,14 @@ mod tests {
 
         for hash_type in hash_types {
             let message_bit_length = hash_type.hash_size() * 8;
-            let private_key = lamport.generate_private_key(
-                master_secret,
-                hash_type,
-                message_bit_length,
-                0,
-            )
-            .unwrap();
+            let private_key = lamport
+                .generate_private_key(master_secret, hash_type, message_bit_length, 0)
+                .unwrap();
 
             // JSON serialization
             let json_serialized = serde_json::to_string(&private_key).unwrap();
-            let json_deserialized: LamportPrivateKey = serde_json::from_str(&json_serialized).unwrap();
+            let json_deserialized: LamportPrivateKey =
+                serde_json::from_str(&json_serialized).unwrap();
             assert_eq!(json_deserialized.hash_type(), hash_type);
             assert_eq!(json_deserialized.to_bytes(), private_key.to_bytes());
             assert_eq!(json_deserialized.derivation_index(), Some(0));

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -2720,7 +2720,10 @@ mod tests {
                 assert_eq!(actual, MAX_MESSAGE_BIT_LENGTH + 1);
                 assert_eq!(max, MAX_MESSAGE_BIT_LENGTH);
             }
-            _ => panic!("Expected MessageBitLengthExceedsMax error - got {:?}", result),
+            _ => panic!(
+                "Expected MessageBitLengthExceedsMax error - got {:?}",
+                result
+            ),
         }
     }
 
@@ -3017,7 +3020,12 @@ mod tests {
         let derivation_index = 123;
 
         let private_key = lamport
-            .generate_private_key(master_secret, LamportType::SHA256, message_bit_length, derivation_index)
+            .generate_private_key(
+                master_secret,
+                LamportType::SHA256,
+                message_bit_length,
+                derivation_index,
+            )
             .unwrap();
         let public_key = private_key.public_key().unwrap();
 

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -31,6 +31,7 @@ pub enum LamportType {
 pub trait HashFunction {
     fn hash(&self, data: &[u8]) -> LamportHash;
     fn hash_size(&self) -> usize;
+    fn hmac(&self, key: &[u8], data: &[u8]) -> Vec<u8>;
 }
 
 impl HashFunction for LamportType {
@@ -62,6 +63,37 @@ impl HashFunction for LamportType {
             LamportType::RIPEMD160 => RIPEMD160_SIZE,
             LamportType::HASH160 => RIPEMD160_SIZE,
             LamportType::HASH256 => SHA256_SIZE,
+        }
+    }
+
+    fn hmac(&self, key: &[u8], data: &[u8]) -> Vec<u8> {
+        match self {
+            LamportType::SHA256 => {
+                let mut engine = HmacEngine::<sha256::Hash>::new(key);
+                engine.input(data);
+                let hmac = Hmac::<sha256::Hash>::from_engine(engine);
+                hmac.as_byte_array().to_vec()
+            }
+            LamportType::RIPEMD160 => {
+                let mut engine = HmacEngine::<ripemd160::Hash>::new(key);
+                engine.input(data);
+                let hmac = Hmac::<ripemd160::Hash>::from_engine(engine);
+                hmac.as_byte_array().to_vec()
+            }
+            LamportType::HASH160 => {
+                // For HASH160, use SHA256 for HMAC, then truncate to RIPEMD160 size
+                let mut engine = HmacEngine::<sha256::Hash>::new(key);
+                engine.input(data);
+                let hmac = Hmac::<sha256::Hash>::from_engine(engine);
+                hmac.as_byte_array().to_vec()
+            }
+            LamportType::HASH256 => {
+                // For HASH256, use SHA256 for HMAC
+                let mut engine = HmacEngine::<sha256::Hash>::new(key);
+                engine.input(data);
+                let hmac = Hmac::<sha256::Hash>::from_engine(engine);
+                hmac.as_byte_array().to_vec()
+            }
         }
     }
 }
@@ -964,17 +996,25 @@ impl Lamport {
         let mut private_key =
             LamportPrivateKey::new(hash_type, message_bit_length, Some(derivation_index));
 
-        let hash_size = hash_type.hash_size();
-
         // Generate key pairs for each bit position
         for i in 0..message_bit_length {
-            // Generate private key for bit value 0
-            let priv_key_0 =
-                self.generate_hash(master_secret, hash_size, derivation_index, i as u32, 0);
+            // Generate private key for bit value 0 (random number derived from master secret, hashed to obtain the necessary bytes)
+            let priv_key_0 = self.generate_priv_keys_randoms_using_hmac_hashing(
+                master_secret,
+                hash_type,
+                derivation_index,
+                i as u32,
+                0,
+            );
 
-            // Generate private key for bit value 1
-            let priv_key_1 =
-                self.generate_hash(master_secret, hash_size, derivation_index, i as u32, 1);
+            // Generate private key for bit value 1 (random number derived from master secret, hashed to obtain the necessary bytes)
+            let priv_key_1 = self.generate_priv_keys_randoms_using_hmac_hashing(
+                master_secret,
+                hash_type,
+                derivation_index,
+                i as u32,
+                1,
+            );
 
             private_key.push_key_pair(priv_key_0, priv_key_1)?;
         }
@@ -1165,25 +1205,25 @@ impl Lamport {
     }
 
     /// Helper function to generate a hash using HMAC for key derivation
-    fn generate_hash(
+    /// Uses the appropriate HMAC hash function based on the hash_type parameter
+    fn generate_priv_keys_randoms_using_hmac_hashing(
         &self,
         master_secret: &[u8],
-        key_size: usize,
+        hash_type: LamportType,
         derivation_index: u32,
         bit_index: u32,
         bit_value: u8, // 0 or 1
     ) -> LamportHash {
-        let mut engine = HmacEngine::<sha256::Hash>::new(master_secret);
         let input = [
             derivation_index.to_le_bytes(),
             bit_index.to_le_bytes(),
             [bit_value, 0, 0, 0],
         ]
         .concat();
-        engine.input(&input);
 
-        let hash = Hmac::<sha256::Hash>::from_engine(engine);
-        LamportHash::new(hash[..key_size].to_vec())
+        let hash_bytes = hash_type.hmac(master_secret, &input);
+        let hash_size = hash_type.hash_size();
+        LamportHash::new(hash_bytes[..hash_size].to_vec())
     }
 }
 

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -312,6 +312,7 @@ impl LamportPublicKey {
     }
 
     // returns all bytes for 0s concatenated with bytes for 1s, in the order of the message bits
+    // we aware this is exporting only the keys without other attributes
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut bytes = Vec::new();
 
@@ -329,6 +330,7 @@ impl LamportPublicKey {
     }
 
     // returns all bytes for 0s at 1st return param, bytes for 1s at the second, in the order of the message bits
+    // we aware this is exporting only the keys without other attributes
     pub fn to_bytes_splitted(&self) -> (Vec<u8>, Vec<u8>) {
         let mut bytes_0s = Vec::new();
         let mut bytes_1s = Vec::new();
@@ -593,6 +595,7 @@ impl LamportPrivateKey {
     }
 
     // returns all bytes for 0s concatenated with bytes for 1s, in the order of the message bits
+    // we aware this is exporting only the keys without other attributes
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut bytes = Vec::new();
 
@@ -610,6 +613,7 @@ impl LamportPrivateKey {
     }
 
     // returns all bytes for 0s at 1st return param, bytes for 1s at the second, in the order of the message bits
+    // we aware this is exporting only the keys without other attributes
     pub fn to_bytes_splitted(&self) -> (Vec<u8>, Vec<u8>) {
         let mut bytes_0s = Vec::new();
         let mut bytes_1s = Vec::new();

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -348,19 +348,12 @@ impl LamportPublicKey {
     // returns all bytes for 0s concatenated with bytes for 1s, in the order of the message bits
     // we aware this is exporting only the keys without other attributes
     pub fn to_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
+        let (bytes_0s, bytes_1s) = self.to_bytes_splitted();
 
-        // Serialize 0s
-        for hash in self.public_key_0s.iter() {
-            bytes.extend_from_slice(&hash.hash);
-        }
-
-        // Serialize 1s
-        for hash in self.public_key_1s.iter() {
-            bytes.extend_from_slice(&hash.hash);
-        }
-
-        bytes
+        let mut combined = Vec::with_capacity(bytes_0s.len() + bytes_1s.len());
+        combined.extend_from_slice(&bytes_0s);
+        combined.extend_from_slice(&bytes_1s);
+        combined
     }
 
     // returns all bytes for 0s at 1st return param, bytes for 1s at the second, in the order of the message bits

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -2666,7 +2666,7 @@ mod tests {
     fn test_dos_protection_public_key_from_bytes() {
         // Try to deserialize with excessive message_bit_length
         let result = LamportPublicKey::from_bytes(
-            &[0u8; 100],
+            &[0u8; (MAX_MESSAGE_BIT_LENGTH + 1) * 32 * 2], // using sha256 size for the test
             MAX_MESSAGE_BIT_LENGTH + 1,
             LamportType::SHA256,
             false,

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use bitcoin::hashes::{ripemd160, sha256, Hash, HashEngine, Hmac, HmacEngine};
 use serde::{Deserialize, Serialize};
 use tracing::warn;
-// use zeroize::Zeroize;
+// use zeroize::Zeroize; // TODO, keep ?
 
 use crate::errors::LamportError;
 
@@ -14,10 +14,10 @@ pub const RIPEMD160_SIZE: usize = 20;
 /// Lamport signature hash function types
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub enum LamportType {
-    // Based on some bitcoin script hash functions, but can be extended in the future if needed
-    // If needed HASH256 (two times sha256) or RIPMED160 (without sha256) could be added here as well
     SHA256,
-    HASH160,
+    RIPEMD160,
+    HASH160, // RIPEMD160(SHA256(x))
+    HASH256, // double SHA-256
 }
 
 pub trait HashFunction {
@@ -31,10 +31,18 @@ impl HashFunction for LamportType {
             LamportType::SHA256 => {
                 LamportHash::new(sha256::Hash::hash(data).as_byte_array().to_vec())
             }
+            LamportType::RIPEMD160 => {
+                LamportHash::new(ripemd160::Hash::hash(data).as_byte_array().to_vec())
+            }
             LamportType::HASH160 => {
                 let sha256 = sha256::Hash::hash(data);
                 let hash160 = ripemd160::Hash::hash(sha256.as_byte_array());
                 LamportHash::new(hash160.as_byte_array().to_vec())
+            }
+            LamportType::HASH256 => {
+                let sha256_1 = sha256::Hash::hash(data);
+                let sha256_2 = sha256::Hash::hash(sha256_1.as_byte_array());
+                LamportHash::new(sha256_2.as_byte_array().to_vec())
             }
         };
         hash
@@ -43,7 +51,9 @@ impl HashFunction for LamportType {
     fn hash_size(&self) -> usize {
         match self {
             LamportType::SHA256 => SHA256_SIZE,
+            LamportType::RIPEMD160 => RIPEMD160_SIZE,
             LamportType::HASH160 => RIPEMD160_SIZE,
+            LamportType::HASH256 => SHA256_SIZE,
         }
     }
 }
@@ -286,6 +296,7 @@ impl LamportPublicKey {
         Ok(())
     }
 
+    // returns all bytes for 0s concatenated with bytes for 1s, in the order of the message bits
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut bytes = Vec::new();
 
@@ -302,17 +313,35 @@ impl LamportPublicKey {
         bytes
     }
 
+    // returns all bytes for 0s at 1st return param, bytes for 1s at the second, in the order of the message bits
+    pub fn to_bytes_splitted(&self) -> (Vec<u8>, Vec<u8>) {
+        let mut bytes_0s = Vec::new();
+        let mut bytes_1s = Vec::new();
+
+        // Serialize 0s
+        for hash in self.public_key_0s.iter() {
+            bytes_0s.extend_from_slice(&hash.hash);
+        }
+
+        // Serialize 1s
+        for hash in self.public_key_1s.iter() {
+            bytes_1s.extend_from_slice(&hash.hash);
+        }
+
+        (bytes_0s, bytes_1s)
+    }
+
     pub fn from_bytes(
-        bytes: &[u8],
+        bytes_0s_then_1s: &[u8],
         message_bit_length: usize,
         hash_type: LamportType,
     ) -> Result<Self, LamportError> {
         let hash_size = hash_type.hash_size();
         let expected_length = 2 * message_bit_length * hash_size;
 
-        if bytes.len() != expected_length {
+        if bytes_0s_then_1s.len() != expected_length {
             return Err(LamportError::InvalidPublicKeyLength(
-                bytes.len(),
+                bytes_0s_then_1s.len(),
                 expected_length,
             ));
         }
@@ -321,8 +350,46 @@ impl LamportPublicKey {
 
         // Split bytes into 0s and 1s sections
         let split_point = message_bit_length * hash_size;
-        let bytes_0s = &bytes[..split_point];
-        let bytes_1s = &bytes[split_point..];
+        let bytes_0s = &bytes_0s_then_1s[..split_point];
+        let bytes_1s = &bytes_0s_then_1s[split_point..];
+
+        for i in 0..message_bit_length {
+            let start = i * hash_size;
+            let end = start + hash_size;
+
+            let hash_0 = LamportHash::new(bytes_0s[start..end].to_vec());
+            let hash_1 = LamportHash::new(bytes_1s[start..end].to_vec());
+
+            public_key.push_key_pair(hash_0, hash_1)?;
+        }
+
+        Ok(public_key)
+    }
+
+    pub fn from_bytes_splitted(
+        bytes_0s: &[u8],
+        bytes_1s: &[u8],
+        message_bit_length: usize,
+        hash_type: LamportType,
+    ) -> Result<Self, LamportError> {
+        let hash_size = hash_type.hash_size();
+        let expected_length = message_bit_length * hash_size;
+
+        if bytes_0s.len() != expected_length {
+            return Err(LamportError::InvalidPublicKeyLength(
+                bytes_0s.len(),
+                expected_length,
+            ));
+        }
+
+        if bytes_1s.len() != expected_length {
+            return Err(LamportError::InvalidPublicKeyLength(
+                bytes_1s.len(),
+                expected_length,
+            ));
+        }
+
+        let mut public_key = LamportPublicKey::new(hash_type, None);
 
         for i in 0..message_bit_length {
             let start = i * hash_size;
@@ -438,7 +505,6 @@ pub struct LamportPrivateKey {
     derivation_index: u32, // TODO what to use if the key was imported and not derived?
 }
 
-// TODO create from bytes or import method?
 impl LamportPrivateKey {
     pub fn new(
         hash_type: LamportType,
@@ -469,20 +535,116 @@ impl LamportPrivateKey {
         Ok(public_key)
     }
 
-    pub fn to_bytes(&self) -> (Vec<u8>, Vec<u8>) {
+    // returns all bytes for 0s concatenated with bytes for 1s, in the order of the message bits
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+
+        // Serialize 0s
+        for hash in self.private_key_0s.iter() {
+            bytes.extend_from_slice(&hash.hash);
+        }
+
+        // Serialize 1s
+        for hash in self.private_key_1s.iter() {
+            bytes.extend_from_slice(&hash.hash);
+        }
+
+        bytes
+    }
+
+    // returns all bytes for 0s at 1st return param, bytes for 1s at the second, in the order of the message bits
+    pub fn to_bytes_splitted(&self) -> (Vec<u8>, Vec<u8>) {
         let mut bytes_0s = Vec::new();
         let mut bytes_1s = Vec::new();
 
-        for hash_0 in self.private_key_0s.iter() {
-            bytes_0s.extend_from_slice(&hash_0.hash);
+        // Serialize 0s
+        for hash in self.private_key_0s.iter() {
+            bytes_0s.extend_from_slice(&hash.hash);
         }
 
-        for hash_1 in self.private_key_1s.iter() {
-            bytes_1s.extend_from_slice(&hash_1.hash);
+        // Serialize 1s
+        for hash in self.private_key_1s.iter() {
+            bytes_1s.extend_from_slice(&hash.hash);
         }
 
         (bytes_0s, bytes_1s)
     }
+
+    pub fn from_bytes(
+        bytes_0s_then_1s: &[u8],
+        message_bit_length: usize,
+        hash_type: LamportType,
+        derivation_index: u32,
+    ) -> Result<Self, LamportError> {
+        let hash_size = hash_type.hash_size();
+        let expected_length = 2 * message_bit_length * hash_size;
+
+        if bytes_0s_then_1s.len() != expected_length {
+            return Err(LamportError::InvalidPublicKeyLength(
+                bytes_0s_then_1s.len(),
+                expected_length,
+            ));
+        }
+
+        let mut private_key = LamportPrivateKey::new(hash_type, message_bit_length, derivation_index);
+
+        // Split bytes into 0s and 1s sections
+        let split_point = message_bit_length * hash_size;
+        let bytes_0s = &bytes_0s_then_1s[..split_point];
+        let bytes_1s = &bytes_0s_then_1s[split_point..];
+
+        for i in 0..message_bit_length {
+            let start = i * hash_size;
+            let end = start + hash_size;
+
+            let hash_0 = LamportHash::new(bytes_0s[start..end].to_vec());
+            let hash_1 = LamportHash::new(bytes_1s[start..end].to_vec());
+
+            private_key.push_key_pair(hash_0, hash_1)?;
+        }
+
+        Ok(private_key)
+    }
+
+    pub fn from_bytes_splitted(
+        bytes_0s: &[u8],
+        bytes_1s: &[u8],
+        message_bit_length: usize,
+        hash_type: LamportType,
+        derivation_index: u32,
+    ) -> Result<Self, LamportError> {
+        let hash_size = hash_type.hash_size();
+        let expected_length = message_bit_length * hash_size;
+
+        if bytes_0s.len() != expected_length {
+            return Err(LamportError::InvalidPublicKeyLength(
+                bytes_0s.len(),
+                expected_length,
+            ));
+        }
+
+        if bytes_1s.len() != expected_length {
+            return Err(LamportError::InvalidPublicKeyLength(
+                bytes_1s.len(),
+                expected_length,
+            ));
+        }
+
+        let mut private_key = LamportPrivateKey::new(hash_type, message_bit_length, derivation_index);
+
+        for i in 0..message_bit_length {
+            let start = i * hash_size;
+            let end = start + hash_size;
+
+            let hash_0 = LamportHash::new(bytes_0s[start..end].to_vec());
+            let hash_1 = LamportHash::new(bytes_1s[start..end].to_vec());
+
+            private_key.push_key_pair(hash_0, hash_1)?;
+        }
+
+        Ok(private_key)
+    }
+
 
     pub fn to_hashes(&self) -> (Vec<Vec<u8>>, Vec<Vec<u8>>) {
         let hashes_0s = self
@@ -511,6 +673,8 @@ impl LamportPrivateKey {
             .collect();
         Ok((hashes_0s?, hashes_1s?))
     }
+
+    // TODO to_hashes_string do we want this, its a secret ?
 
     pub fn len(&self) -> usize {
         self.private_key_0s.len()
@@ -665,12 +829,12 @@ impl Lamport {
     }
 
 
-    // TODO Sing and Verify by message bits, and also by messages bytes, as for many cases using SHA256 as hash function will imply that the message is really the message digest, obtained by hashing also the message, so it willl be 32 exact bytes
+    // TODO Sign and Verify by message bits, and also by messages bytes, as for many cases using SHA256 as hash function will imply that the message is really the message digest, obtained by hashing also the message, so it willl be 32 exact bytes
 
     /// Sign a message using a Lamport private key
     ///
     /// # Arguments
-    /// * `message_bits` - The message to sign as a vector of bits (0s and 1s)
+    /// * `message_bits` - The message to sign as a vector of bits (boolean array)
     /// * `private_key` - The private key to use for signing
     ///
     /// # Returns
@@ -681,7 +845,7 @@ impl Lamport {
     /// Reusing a Lamport private key allows attackers to forge signatures.
     pub fn sign_message(
         &self,
-        message_bits: &[u8], // TODO i prefer to be an array of booleans, as a bit is only 0 or 1
+        message_bits: &[bool],
         private_key: &LamportPrivateKey,
     ) -> Result<LamportSignature, LamportError> {
         if message_bits.len() != private_key.message_bit_length() {
@@ -695,12 +859,10 @@ impl Lamport {
 
         // For each bit, reveal the corresponding private key
         for (i, &bit) in message_bits.iter().enumerate() {
-            let revealed_key = if bit == 1 {
+            let revealed_key = if bit {
                 private_key.private_key_1_at(i)?.clone()
-            } else if bit == 0 {
-                private_key.private_key_0_at(i)?.clone()
             } else {
-                return Err(LamportError::InvalidBitValue(bit));
+                private_key.private_key_0_at(i)?.clone()
             };
 
             signature.push_revealed_key(revealed_key)?;
@@ -712,7 +874,7 @@ impl Lamport {
     /// Verify a Lamport signature
     ///
     /// # Arguments
-    /// * `message_bits` - The message that was allegedly signed (as bits)
+    /// * `message_bits` - The message that was allegedly signed (as boolean array)
     /// * `signature` - The signature to verify
     /// * `public_key` - The public key to verify against
     ///
@@ -720,7 +882,7 @@ impl Lamport {
     /// True if the signature is valid, false otherwise
     pub fn verify_signature(
         &self,
-        message_bits: &[u8], // TODO i prefer to be an array of booleans, as a bit is only 0 or 1
+        message_bits: &[bool],
         signature: &LamportSignature,
         public_key: &LamportPublicKey,
     ) -> Result<bool, LamportError> {
@@ -745,13 +907,10 @@ impl Lamport {
             let revealed_key = signature.revealed_key_at(i)?;
             let hash_of_revealed = hash_type.hash(&revealed_key.to_bytes());
 
-            let expected_public_key = if bit == 1 {
+            let expected_public_key = if bit {
                 public_key.public_key_1_at(i)?
-            } else if bit == 0 {
-                public_key.public_key_0_at(i)?
             } else {
-                warn!("Invalid bit value: {} (expected 0 or 1)", bit);
-                return Ok(false);
+                public_key.public_key_0_at(i)?
             };
 
             if hash_of_revealed != *expected_public_key {
@@ -788,13 +947,19 @@ impl Lamport {
 // TODO padding should be added as a parameter, to know how many start 0s are not part of the message, for the funcs that call using exactly all the bits that fits in that bytes padding will be 0
 /// Convert a byte array to a bit array
 /// Each byte is expanded to 8 bits (MSB first)
-pub fn bytes_to_bits(bytes: &[u8]) -> Vec<u8> {
+pub fn bytes_to_bits(bytes: &[u8]) -> Vec<bool> {
     let mut bits = Vec::with_capacity(bytes.len() * 8);
 
     for byte in bytes {
         for bit_index in 0..8 {
             let bit = (byte >> (7 - bit_index)) & 1;
-            bits.push(bit);
+            bits.push(bit == 1);
+            // Example extracting bits from byte 0b10110011 (179 in decimal):
+            // bit_index=0: byte >> (7-0) = 0b10110011 >> 7 = 0b00000001, & 1 = 1 → bit = 1 (MSB, push true)
+            // bit_index=1: byte >> (7-1) = 0b10110011 >> 6 = 0b00000010, & 1 = 0 → bit = 0 (push false)
+            // ...
+            // bit_index=7: byte >> (7-7) = 0b10110011 >> 0 = 0b10110011, & 1 = 1 → bit = 1 (push true, LSB)
+            // Result: [true, false, true, true, false, false, true, true] representing bits from MSB to LSB
         }
     }
 
@@ -804,7 +969,7 @@ pub fn bytes_to_bits(bytes: &[u8]) -> Vec<u8> {
 // TODO padding should be added as a return value, to know how many start 0s of the 1st byte are not part of the message, for the cases converting bits mutiple of 8 the padding will be 0
 /// Convert a bit array back to bytes
 /// Every 8 bits are combined into one byte (MSB first)
-pub fn bits_to_bytes(bits: &[u8]) -> Result<Vec<u8>, LamportError> {
+pub fn bits_to_bytes(bits: &[bool]) -> Result<Vec<u8>, LamportError> {
     if bits.len() % 8 != 0 {
         return Err(LamportError::InvalidBitLength(bits.len()));
     }
@@ -814,10 +979,15 @@ pub fn bits_to_bytes(bits: &[u8]) -> Result<Vec<u8>, LamportError> {
     for chunk in bits.chunks(8) {
         let mut byte = 0u8;
         for (i, &bit) in chunk.iter().enumerate() {
-            if bit > 1 {
-                return Err(LamportError::InvalidBitValue(bit));
+            if bit {
+                byte |= 1 << (7 - i); // bitwise or
+                // Example building byte 0b10110011 from bits [true, false, true, true, false, false, true, true]:
+                // i=0, bit=true:  1 << (7-0) = 1 << 7 = 0b10000000, byte |= 0b10000000 → byte = 0b10000000
+                // i=1, bit=false: skipped (if bit is false, don't set the bit)
+                // ...
+                // i=7, bit=true:  1 << (7-7) = 1 << 0 = 0b00000001, byte |= 0b00000001 → byte = 0b10110011
+                // Result: byte = 0b10110011 (179 in decimal)
             }
-            byte |= bit << (7 - i);
         }
         bytes.push(byte);
     }
@@ -830,7 +1000,7 @@ mod tests {
     use super::*;
 
 
-    // TODO in this test we assume we alsay have the hole byte filled with bits, we should create another tests, where we have 4 bits and padding, (filled with 0s at the begining) and 1 lonely bit with 7 0s as padding
+    // TODO in this test we assume we always have the hole byte filled with bits, we should create another tests, where we have 4 bits and padding, (filled with 0s at the begining) and 1 lonely bit with 7 0s as padding
     #[test]
     fn test_bytes_to_bits_and_back() {
         let original_bytes = vec![0b10110011, 0b01001100, 0xFF, 0x00];

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -10,6 +10,8 @@ use crate::errors::LamportError;
 pub const SHA256_SIZE: usize = 32;
 pub const RIPEMD160_SIZE: usize = 20;
 
+// TODO add a max length to prevent DoS with huge keys/signatures?
+
 /// Lamport signature hash function types
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub enum LamportType {
@@ -1635,5 +1637,640 @@ mod tests {
                 .verify_signature_bit(!wire_value, &signatures[i], &pubkeys[i])
                 .unwrap());
         }
+    }
+
+    // ========== Additional Hash Type Tests ==========
+
+    #[test]
+    fn test_lamport_ripemd160_sign_and_verify() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret_12345678901234567890";
+        let message_bit_length = 160; // 20 bytes for RIPEMD160
+
+        let private_key = lamport
+            .generate_private_key(master_secret, LamportType::RIPEMD160, message_bit_length, 0)
+            .unwrap();
+        let public_key = private_key.public_key().unwrap();
+
+        assert_eq!(public_key.hash_size(), RIPEMD160_SIZE);
+        assert_eq!(public_key.hash_type(), LamportType::RIPEMD160);
+
+        let message_bytes = [0x42u8; 20]; // Sign a 20-byte message
+        let signature = lamport.sign_message_bytes(&message_bytes, &private_key).unwrap();
+
+        assert!(lamport.verify_signature_bytes(&message_bytes, &signature, &public_key).unwrap());
+
+        // Test with wrong message
+        let wrong_message = [0x43u8; 20];
+        assert!(!lamport.verify_signature_bytes(&wrong_message, &signature, &public_key).unwrap());
+    }
+
+    #[test]
+    fn test_lamport_hash256_sign_and_verify() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret_12345678901234567890";
+        let message_bit_length = 256; // 32 bytes for HASH256 (double SHA256)
+
+        let private_key = lamport
+            .generate_private_key(master_secret, LamportType::HASH256, message_bit_length, 0)
+            .unwrap();
+        let public_key = private_key.public_key().unwrap();
+
+        assert_eq!(public_key.hash_size(), SHA256_SIZE);
+        assert_eq!(public_key.hash_type(), LamportType::HASH256);
+
+        let message_bytes = [0xAAu8; 32]; // Sign a 32-byte message
+        let signature = lamport.sign_message_bytes(&message_bytes, &private_key).unwrap();
+
+        assert!(lamport.verify_signature_bytes(&message_bytes, &signature, &public_key).unwrap());
+
+        // Test with wrong message
+        let wrong_message = [0xBBu8; 32];
+        assert!(!lamport.verify_signature_bytes(&wrong_message, &signature, &public_key).unwrap());
+    }
+
+    #[test]
+    fn test_all_hash_types_produce_correct_sizes() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret";
+
+        // Test each hash type
+        let test_cases = vec![
+            (LamportType::SHA256, SHA256_SIZE),
+            (LamportType::RIPEMD160, RIPEMD160_SIZE),
+            (LamportType::HASH160, RIPEMD160_SIZE),
+            (LamportType::HASH256, SHA256_SIZE),
+        ];
+
+        for (hash_type, expected_size) in test_cases {
+            let private_key = lamport
+                .generate_private_key(master_secret, hash_type, 8, 0)
+                .unwrap();
+            let public_key = private_key.public_key().unwrap();
+
+            assert_eq!(public_key.hash_size(), expected_size, "Hash type: {:?}", hash_type);
+            assert_eq!(private_key.hash_size(), expected_size, "Hash type: {:?}", hash_type);
+        }
+    }
+
+    // ========== Error Handling Tests ==========
+
+    #[test]
+    fn test_error_invalid_signature_length() {
+        let bytes = vec![0u8; 100]; // Wrong length
+        let result = LamportSignature::from_bytes(&bytes, 256, LamportType::SHA256);
+        assert!(result.is_err());
+        if let Err(LamportError::InvalidSignatureLength(got, expected)) = result {
+            assert_eq!(got, 100);
+            assert_eq!(expected, 256 * 32);
+        } else {
+            panic!("Expected InvalidSignatureLength error");
+        }
+    }
+
+    #[test]
+    fn test_error_invalid_public_key_length() {
+        let bytes = vec![0u8; 100]; // Wrong length
+        let result = LamportPublicKey::from_bytes(&bytes, 256, LamportType::SHA256);
+        assert!(result.is_err());
+        if let Err(LamportError::InvalidPublicKeyLength(got, expected)) = result {
+            assert_eq!(got, 100);
+            assert_eq!(expected, 2 * 256 * 32);
+        } else {
+            panic!("Expected InvalidPublicKeyLength error");
+        }
+    }
+
+    #[test]
+    fn test_error_message_length_mismatch() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret";
+
+        let private_key = lamport
+            .generate_private_key(master_secret, LamportType::SHA256, 128, 0)
+            .unwrap();
+
+        // Try to sign a message with wrong bit length
+        let wrong_message_bits = vec![false; 256]; // 256 bits instead of 128
+        let result = lamport.sign_message(&wrong_message_bits, &private_key);
+
+        assert!(result.is_err());
+        if let Err(LamportError::MessageLengthMismatch(got, expected)) = result {
+            assert_eq!(got, 256);
+            assert_eq!(expected, 128);
+        } else {
+            panic!("Expected MessageLengthMismatch error");
+        }
+    }
+
+    #[test]
+    fn test_error_hash_size_mismatch_in_to_array() {
+        // Create a hash with size != 32
+        let hash = LamportHash::new(vec![0u8; 20]);
+        let result = hash.to_array();
+
+        assert!(result.is_err());
+        if let Err(LamportError::InvalidHashSize(got, expected)) = result {
+            assert_eq!(got, 20);
+            assert_eq!(expected, 32);
+        } else {
+            panic!("Expected InvalidHashSize error");
+        }
+    }
+
+    #[test]
+    fn test_error_extra_data_missing() {
+        let public_key = LamportPublicKey::new(LamportType::SHA256, None);
+
+        let result = public_key.message_bit_length();
+        assert!(result.is_err());
+        assert!(matches!(result, Err(LamportError::ExtraDataMissing(_))));
+
+        let result = public_key.derivation_index();
+        assert!(result.is_err());
+        assert!(matches!(result, Err(LamportError::ExtraDataMissing(_))));
+    }
+
+    #[test]
+    fn test_error_index_overflow() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret";
+
+        // Try to use max u32 value, which would overflow when incremented
+        let result = lamport.generate_private_key(master_secret, LamportType::SHA256, 8, u32::MAX);
+
+        assert!(result.is_err());
+        assert!(matches!(result, Err(LamportError::IndexOverflow)));
+    }
+
+    // ========== Serialization Tests ==========
+
+    #[test]
+    fn test_private_key_serialization_from_bytes() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret";
+        let message_bit_length = 128;
+
+        let private_key = lamport
+            .generate_private_key(master_secret, LamportType::SHA256, message_bit_length, 0)
+            .unwrap();
+
+        let bytes = private_key.to_bytes();
+        let reconstructed = LamportPrivateKey::from_bytes(
+            &bytes,
+            message_bit_length,
+            LamportType::SHA256,
+            0,
+        )
+        .unwrap();
+
+        assert_eq!(private_key.len(), reconstructed.len());
+        assert_eq!(private_key.to_bytes(), reconstructed.to_bytes());
+        assert_eq!(private_key.message_bit_length(), reconstructed.message_bit_length());
+        assert_eq!(private_key.derivation_index(), reconstructed.derivation_index());
+    }
+
+    #[test]
+    fn test_private_key_serialization_from_bytes_splitted() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret";
+        let message_bit_length = 64;
+
+        let private_key = lamport
+            .generate_private_key(master_secret, LamportType::HASH160, message_bit_length, 5)
+            .unwrap();
+
+        let (bytes_0s, bytes_1s) = private_key.to_bytes_splitted();
+        let reconstructed = LamportPrivateKey::from_bytes_splitted(
+            &bytes_0s,
+            &bytes_1s,
+            message_bit_length,
+            LamportType::HASH160,
+            5,
+        )
+        .unwrap();
+
+        assert_eq!(private_key.to_bytes(), reconstructed.to_bytes());
+        assert_eq!(private_key.derivation_index(), reconstructed.derivation_index());
+    }
+
+    #[test]
+    fn test_public_key_serialization_from_bytes_splitted() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret";
+        let message_bit_length = 64;
+
+        let private_key = lamport
+            .generate_private_key(master_secret, LamportType::SHA256, message_bit_length, 7)
+            .unwrap();
+        let public_key = private_key.public_key().unwrap();
+
+        let (bytes_0s, bytes_1s) = public_key.to_bytes_splitted();
+        let reconstructed = LamportPublicKey::from_bytes_splitted(
+            &bytes_0s,
+            &bytes_1s,
+            message_bit_length,
+            LamportType::SHA256,
+        )
+        .unwrap();
+
+        assert_eq!(public_key.to_bytes(), reconstructed.to_bytes());
+    }
+
+    #[test]
+    fn test_signature_serialization() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret";
+        let message_bit_length = 128;
+
+        let private_key = lamport
+            .generate_private_key(master_secret, LamportType::SHA256, message_bit_length, 0)
+            .unwrap();
+
+        let message_bytes = [0x42u8; 16]; // 128 bits
+        let signature = lamport.sign_message_bytes(&message_bytes, &private_key).unwrap();
+
+        let bytes = signature.to_bytes();
+        let reconstructed = LamportSignature::from_bytes(
+            &bytes,
+            message_bit_length,
+            LamportType::SHA256,
+        )
+        .unwrap();
+
+        assert_eq!(signature.len(), reconstructed.len());
+        assert_eq!(signature.to_bytes(), reconstructed.to_bytes());
+        assert_eq!(signature.message_bit_length(), reconstructed.message_bit_length());
+    }
+
+    // ========== Array Conversion Tests ==========
+
+    #[test]
+    fn test_to_array_hashes_private_key() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret";
+        let message_bit_length = 16;
+
+        let private_key = lamport
+            .generate_private_key(master_secret, LamportType::SHA256, message_bit_length, 0)
+            .unwrap();
+
+        let result = private_key.to_array_hashes();
+        assert!(result.is_ok());
+
+        let (hashes_0s, hashes_1s) = result.unwrap();
+        assert_eq!(hashes_0s.len(), message_bit_length);
+        assert_eq!(hashes_1s.len(), message_bit_length);
+    }
+
+    #[test]
+    fn test_to_array_hashes_public_key() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret";
+        let message_bit_length = 16;
+
+        let private_key = lamport
+            .generate_private_key(master_secret, LamportType::SHA256, message_bit_length, 0)
+            .unwrap();
+        let public_key = private_key.public_key().unwrap();
+
+        let result = public_key.to_array_hashes();
+        assert!(result.is_ok());
+
+        let (hashes_0s, hashes_1s) = result.unwrap();
+        assert_eq!(hashes_0s.len(), message_bit_length);
+        assert_eq!(hashes_1s.len(), message_bit_length);
+    }
+
+    #[test]
+    fn test_to_array_hashes_signature() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret";
+        let message_bit_length = 16;
+
+        let private_key = lamport
+            .generate_private_key(master_secret, LamportType::SHA256, message_bit_length, 0)
+            .unwrap();
+
+        let message_bytes = [0x42u8; 2]; // 16 bits
+        let signature = lamport.sign_message_bytes(&message_bytes, &private_key).unwrap();
+
+        let result = signature.to_array_hashes();
+        assert!(result.is_ok());
+
+        let hashes = result.unwrap();
+        assert_eq!(hashes.len(), message_bit_length);
+    }
+
+    #[test]
+    fn test_to_hashes_methods() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret";
+        let message_bit_length = 8;
+
+        let private_key = lamport
+            .generate_private_key(master_secret, LamportType::SHA256, message_bit_length, 0)
+            .unwrap();
+        let public_key = private_key.public_key().unwrap();
+
+        // Test private key to_hashes
+        let (priv_0s, priv_1s) = private_key.to_hashes();
+        assert_eq!(priv_0s.len(), message_bit_length);
+        assert_eq!(priv_1s.len(), message_bit_length);
+
+        // Test public key to_hashes
+        let (pub_0s, pub_1s) = public_key.to_hashes();
+        assert_eq!(pub_0s.len(), message_bit_length);
+        assert_eq!(pub_1s.len(), message_bit_length);
+
+        // Test signature to_hashes
+        let message_bytes = [0x42u8; 1];
+        let signature = lamport.sign_message_bytes(&message_bytes, &private_key).unwrap();
+        let sig_hashes = signature.to_hashes();
+        assert_eq!(sig_hashes.len(), message_bit_length);
+    }
+
+    #[test]
+    fn test_to_hashes_string() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret";
+        let message_bit_length = 8;
+
+        let private_key = lamport
+            .generate_private_key(master_secret, LamportType::SHA256, message_bit_length, 0)
+            .unwrap();
+        let public_key = private_key.public_key().unwrap();
+
+        let (priv_0s_str, priv_1s_str) = private_key.to_hashes_string();
+        assert_eq!(priv_0s_str.len(), message_bit_length);
+        assert_eq!(priv_1s_str.len(), message_bit_length);
+        // Each should be a hex string (64 chars for SHA256)
+        for hash_str in &priv_0s_str {
+            assert_eq!(hash_str.len(), 64);
+        }
+
+        let (pub_0s_str, pub_1s_str) = public_key.to_hashes_string();
+        assert_eq!(pub_0s_str.len(), message_bit_length);
+        assert_eq!(pub_1s_str.len(), message_bit_length);
+    }
+
+    // ========== ExtraData Tests ==========
+
+    #[test]
+    fn test_extra_data_getters() {
+        let extra_data = ExtraData::new(256, 42);
+
+        assert_eq!(extra_data.message_bit_length(), 256);
+        assert_eq!(extra_data.derivation_index(), 42);
+    }
+
+    #[test]
+    fn test_public_key_extra_data() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret";
+        let message_bit_length = 128;
+        let derivation_index = 99;
+
+        let private_key = lamport
+            .generate_private_key(master_secret, LamportType::SHA256, message_bit_length, derivation_index)
+            .unwrap();
+        let public_key = private_key.public_key().unwrap();
+
+        assert!(public_key.extra_data().is_some());
+        assert_eq!(public_key.message_bit_length().unwrap(), message_bit_length);
+        assert_eq!(public_key.derivation_index().unwrap(), derivation_index);
+    }
+
+    // ========== Cross-Hash-Type Validation Tests ==========
+
+    #[test]
+    fn test_cross_hash_type_verification_fails() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret";
+        let message_bit_length = 128;
+
+        // Sign with SHA256
+        let private_key_sha256 = lamport
+            .generate_private_key(master_secret, LamportType::SHA256, message_bit_length, 0)
+            .unwrap();
+        let message_bytes = [0x42u8; 16];
+        let signature = lamport.sign_message_bytes(&message_bytes, &private_key_sha256).unwrap();
+
+        // Try to verify with a HASH160 public key (different hash type)
+        let private_key_hash160 = lamport
+            .generate_private_key(master_secret, LamportType::HASH160, message_bit_length, 0)
+            .unwrap();
+        let public_key_hash160 = private_key_hash160.public_key().unwrap();
+
+        // This should fail because hash types don't match
+        let is_valid = lamport.verify_signature_bytes(&message_bytes, &signature, &public_key_hash160).unwrap();
+        assert!(!is_valid);
+    }
+
+    // ========== LamportHash Tests ==========
+
+    #[test]
+    fn test_lamport_hash_is_empty() {
+        let empty_hash = LamportHash::new(vec![]);
+        assert!(empty_hash.is_empty());
+        assert_eq!(empty_hash.len(), 0);
+
+        let non_empty_hash = LamportHash::new(vec![1, 2, 3]);
+        assert!(!non_empty_hash.is_empty());
+        assert_eq!(non_empty_hash.len(), 3);
+    }
+
+    #[test]
+    fn test_lamport_hash_to_hex() {
+        let hash = LamportHash::new(vec![0xDE, 0xAD, 0xBE, 0xEF]);
+        assert_eq!(hash.to_hex(), "deadbeef");
+    }
+
+    #[test]
+    fn test_lamport_hash_to_bytes() {
+        let original_bytes = vec![1, 2, 3, 4, 5];
+        let hash = LamportHash::new(original_bytes.clone());
+        assert_eq!(hash.to_bytes(), original_bytes);
+    }
+
+    // ========== Edge Cases ==========
+
+    #[test]
+    fn test_empty_message_bits() {
+        let (bytes, padding) = bits_to_bytes(&[]).unwrap();
+        assert_eq!(bytes.len(), 0);
+        assert_eq!(padding, 0);
+
+        let bits = bytes_to_bits(&[], 0);
+        assert_eq!(bits.len(), 0);
+    }
+
+    #[test]
+    fn test_single_byte_edge_cases() {
+        // Test all possible single byte values
+        for byte_val in [0x00, 0xFF, 0x55, 0xAA, 0x01, 0x80] {
+            let bytes = vec![byte_val];
+            let bits = bytes_to_bits(&bytes, 0);
+            let (reconstructed_bytes, padding) = bits_to_bytes(&bits).unwrap();
+            assert_eq!(reconstructed_bytes, bytes);
+            assert_eq!(padding, 0);
+        }
+    }
+
+    #[test]
+    fn test_signature_length_getters() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret";
+        let message_bit_length = 64;
+
+        let private_key = lamport
+            .generate_private_key(master_secret, LamportType::SHA256, message_bit_length, 0)
+            .unwrap();
+
+        let message_bytes = [0x42u8; 8];
+        let signature = lamport.sign_message_bytes(&message_bytes, &private_key).unwrap();
+
+        assert_eq!(signature.len(), message_bit_length);
+        assert!(!signature.is_empty());
+        assert_eq!(signature.message_bit_length(), message_bit_length);
+        assert_eq!(signature.hash_type(), LamportType::SHA256);
+    }
+
+    #[test]
+    fn test_private_key_length_getters() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret";
+        let message_bit_length = 32;
+
+        let private_key = lamport
+            .generate_private_key(master_secret, LamportType::HASH160, message_bit_length, 7)
+            .unwrap();
+
+        assert_eq!(private_key.len(), message_bit_length);
+        assert!(!private_key.is_empty());
+        assert_eq!(private_key.message_bit_length(), message_bit_length);
+        assert_eq!(private_key.derivation_index(), 7);
+        assert_eq!(private_key.hash_type(), LamportType::HASH160);
+    }
+
+    #[test]
+    fn test_public_key_length_getters() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret";
+        let message_bit_length = 32;
+
+        let private_key = lamport
+            .generate_private_key(master_secret, LamportType::SHA256, message_bit_length, 0)
+            .unwrap();
+        let public_key = private_key.public_key().unwrap();
+
+        assert_eq!(public_key.len(), message_bit_length);
+        assert!(!public_key.is_empty());
+        assert_eq!(public_key.hash_size(), SHA256_SIZE);
+    }
+
+    #[test]
+    fn test_lamport_type_display() {
+        assert_eq!(format!("{}", LamportType::SHA256), "SHA256");
+        assert_eq!(format!("{}", LamportType::RIPEMD160), "RIPEMD160");
+        assert_eq!(format!("{}", LamportType::HASH160), "HASH160");
+        assert_eq!(format!("{}", LamportType::HASH256), "HASH256");
+    }
+
+    #[test]
+    fn test_lamport_type_parsing_all_variants() {
+        // Test case insensitivity
+        assert_eq!(LamportType::from_str("SHA256").unwrap(), LamportType::SHA256);
+        assert_eq!(LamportType::from_str("sha256").unwrap(), LamportType::SHA256);
+        assert_eq!(LamportType::from_str("SHa256").unwrap(), LamportType::SHA256);
+
+        assert_eq!(LamportType::from_str("HASH160").unwrap(), LamportType::HASH160);
+        assert_eq!(LamportType::from_str("hash160").unwrap(), LamportType::HASH160);
+
+        // Test invalid types
+        assert!(LamportType::from_str("RIPEMD160").is_err());
+        assert!(LamportType::from_str("HASH256").is_err());
+        assert!(LamportType::from_str("MD5").is_err());
+        assert!(LamportType::from_str("").is_err());
+    }
+
+    #[test]
+    fn test_derive_multiple_keys_same_master_secret() {
+        let lamport = Lamport::new();
+        let master_secret = b"shared_master_secret";
+        let message_bit_length = 64;
+
+        // Generate multiple keys with different indices
+        let mut keys = Vec::new();
+        for i in 0..5 {
+            let key = lamport
+                .generate_private_key(master_secret, LamportType::SHA256, message_bit_length, i)
+                .unwrap();
+            keys.push(key);
+        }
+
+        // Verify all keys are different
+        for i in 0..keys.len() {
+            for j in (i + 1)..keys.len() {
+                assert_ne!(keys[i].to_bytes(), keys[j].to_bytes());
+            }
+        }
+    }
+
+    #[test]
+    fn test_deterministic_key_generation() {
+        let lamport = Lamport::new();
+        let master_secret = b"deterministic_secret";
+        let message_bit_length = 128;
+        let derivation_index = 42;
+
+        // Generate the same key twice
+        let key1 = lamport
+            .generate_private_key(master_secret, LamportType::SHA256, message_bit_length, derivation_index)
+            .unwrap();
+        let key2 = lamport
+            .generate_private_key(master_secret, LamportType::SHA256, message_bit_length, derivation_index)
+            .unwrap();
+
+        // They should be identical
+        assert_eq!(key1.to_bytes(), key2.to_bytes());
+
+        let pub1 = key1.public_key().unwrap();
+        let pub2 = key2.public_key().unwrap();
+        assert_eq!(pub1.to_bytes(), pub2.to_bytes());
+    }
+
+    #[test]
+    fn test_max_safe_derivation_index() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_secret";
+
+        // u32::MAX should fail
+        let result = lamport.generate_private_key(master_secret, LamportType::SHA256, 8, u32::MAX);
+        assert!(result.is_err());
+
+        // u32::MAX - 1 should succeed
+        let result = lamport.generate_private_key(master_secret, LamportType::SHA256, 8, u32::MAX - 1);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_large_message_bit_length() {
+        let lamport = Lamport::new();
+        let master_secret = b"test_master_secret";
+        let message_bit_length = 1024; // Large message
+
+        let private_key = lamport
+            .generate_private_key(master_secret, LamportType::SHA256, message_bit_length, 0)
+            .unwrap();
+        let public_key = private_key.public_key().unwrap();
+
+        assert_eq!(private_key.len(), message_bit_length);
+        assert_eq!(public_key.len(), message_bit_length);
+
+        // Sign and verify a large message
+        let message_bytes = vec![0x42u8; 128]; // 1024 bits
+        let signature = lamport.sign_message_bytes(&message_bytes, &private_key).unwrap();
+        assert!(lamport.verify_signature_bytes(&message_bytes, &signature, &public_key).unwrap());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod errors;
 pub mod key_manager;
 pub mod key_store;
 pub mod key_type;
+pub mod lamport;
 pub mod musig2;
 pub mod rsa;
 pub mod tests;

--- a/src/winternitz.rs
+++ b/src/winternitz.rs
@@ -617,9 +617,8 @@ impl Winternitz {
         checksum_size: usize,
         derivation_index: u32,
     ) -> Result<WinternitzPrivateKey, WinternitzError> {
-        derivation_index
-            .checked_add(1)
-            .ok_or(WinternitzError::IndexOverflow)?;
+
+        validate_following_derivation_index(derivation_index)?;
 
         let mut private_key =
             WinternitzPrivateKey::new(key_type, derivation_index, message_size, checksum_size);
@@ -737,4 +736,15 @@ fn to_digits(mut number: u32, number_of_digits: usize) -> Vec<u8> {
 
     digits.resize(number_of_digits, 0);
     digits
+}
+
+// ========== Validation Helper Functions ==========
+
+/// Validates that we are 1 index below the overflow threshold for u32
+fn validate_following_derivation_index(derivation_index: u32) -> Result<(), WinternitzError> {
+    derivation_index
+        .checked_add(1)
+        .ok_or(WinternitzError::IndexOverflow)?;
+
+    Ok(())
 }

--- a/src/winternitz.rs
+++ b/src/winternitz.rs
@@ -617,7 +617,6 @@ impl Winternitz {
         checksum_size: usize,
         derivation_index: u32,
     ) -> Result<WinternitzPrivateKey, WinternitzError> {
-
         validate_following_derivation_index(derivation_index)?;
 
         let mut private_key =

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -15,6 +15,27 @@ mod deriving_winternitz_example {
     }
 }
 
+mod deriving_lamport_example {
+    include!("../examples/deriving_lamport.rs");
+    pub fn run_example() {
+        main();
+    }
+}
+
+mod import_lamport_example {
+    include!("../examples/import_lamport.rs");
+    pub fn run_example() {
+        main();
+    }
+}
+
+mod sign_verify_lamport_example {
+    include!("../examples/sign_verify_lamport.rs");
+    pub fn run_example() {
+        main();
+    }
+}
+
 mod key_gen_example {
     include!("../examples/key_gen.rs");
     pub fn run_example() {
@@ -148,6 +169,27 @@ mod tests {
     fn test_sign_verify_musig2_example() {
         setup_and_cleanup(|| {
             super::sign_verify_musig2_example::run_example();
+        });
+    }
+
+    #[test]
+    fn test_deriving_lamport_example() {
+        setup_and_cleanup(|| {
+            super::deriving_lamport_example::run_example();
+        });
+    }
+
+    #[test]
+    fn test_import_lamport_example() {
+        setup_and_cleanup(|| {
+            super::import_lamport_example::run_example();
+        });
+    }
+
+    #[test]
+    fn test_sign_verify_lamport_example() {
+        setup_and_cleanup(|| {
+            super::sign_verify_lamport_example::run_example();
         });
     }
 }


### PR DESCRIPTION
## Add Lamport One-Time Signatures Support

This PR introduces support for Lamport one-time signatures with multi-hash type support, automatic index management, and key import capabilities. Ensuring compatibility with Fairgate garbled circuits wires bits to be imported, signed and verified.

### Features

- **Lamport Signature Module** (`src/lamport.rs`)
  - Complete implementation of Lamport one-time signatures
  - Support for multiple hash types: `SHA256`, `RIPEMD160`, `HASH160`, `HASH256`
  - Flexible signing/verification: single bit, bit arrays, or byte arrays
  - Key Cryptographic Serialization (without extra data): standard and split-key formats, full serialization is able via serde
  - DoS protection with configurable max message bit length

- **KeyManager Integration**
  - Automatic derivation index management with `next_lamport()`
  - Manual derivation with `derive_lamport()` for advanced use cases  
  - BIP-39/BIP-44 HD derivation path for Lamport keys (purpose index: `986`)
  - Lamport master seed derived from key derivation seed with validation

- **Import Support**
  - `import_lamport_private_key()` for importing external Lamport keys
  - Tracking of imported vs derived keys
  - One-time use enforcement for both derived and imported keys

- **Key Store Enhancements**
  - Bitmap-based index tracking to prevent key reuse
  - Spent key detection at signing time
  - blake3 hashing for storage keys
  - Separate counters per hash type and message bit length

### Public API Additions

**KeyManager:**
- `next_lamport(message_bit_length, key_type)` → `LamportPublicKey` 
- `next_multiple_lamport(message_bit_length, key_type, number_of_keys) → Vec<LamportPublicKey>`
- `import_lamport_private_key(bytes_0s, bytes_1s, message_bit_length, hash_type)` → `LamportPublicKey`
- `sign_lamport(message_bytes, public_key)` → `LamportSignature`
- `verify_lamport(message_bytes, signature, public_key)` → `bool`

**Lamport Module:**
- `Lamport::new()` - Constructor
- `generate_public_key()`, `generate_private_key()` - Key generation
- `sign_message()`, `sign_message_bit()`, `sign_message_bytes()` - Signing variants
- `verify_signature()`, `verify_signature_bit()`, `verify_signature_bytes()` - Verification variants
- To bytes with split-key support

### Examples Added

- `examples/deriving_lamport.rs` - Key derivation workflow
- `examples/import_lamport.rs` - Import external keys (64 lines)
- `examples/sign_verify_lamport.rs` - Sign and verify messages (47 lines)

### Testing

- Unit tests:
- Integration tests for KeyManager functions and examples
