### PR TITLE
Add compressed lamport pubkey fingerprint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ uuid = { version = "1.10.0", features = ["v4"] }
 [dev-dependencies]
 criterion = "0.6.0"
 rand = "0.9.0"
+bincode = "1"
 
 [[bin]]
 name = "key-manager"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ name = "key_manager"
 anyhow = "1.0.97"
 bitcoin = { version = "0.32.6", features = ["std", "rand-std", "serde"] }
 bip39 = "2.1.0"
-blake3 = "1.5"
+blake3 = { version = "1.5", features = ["serde"] }
 clap = { version = "4.5.32", features = ["derive"] }
 config = "0.15.11"
 itertools = "0.14.0"

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The `KeyManager` supports MuSig2 multi-signature schemes, allowing multiple part
 
 1. Clone the repository
 2. Install dependencies: `cargo build`
-3. Run tests: `cargo test -- --test-threads=1`
+3. Run tests: `cargo test --release -- --test-threads=1`
 
 ## Examples
 

--- a/examples/sign_verify_lamport.rs
+++ b/examples/sign_verify_lamport.rs
@@ -6,7 +6,7 @@ use bitcoin::hashes::{sha256, Hash};
 use bitcoin::key::rand::RngCore;
 use bitcoin::secp256k1;
 
-use key_manager::lamport::{bits_to_bytes, Lamport, LamportType};
+use key_manager::lamport::{bits_to_bytes, Lamport, LamportCompressedPubKey, LamportType};
 
 fn main() {
     // see function code, main is just a wrapper to run the example
@@ -122,11 +122,38 @@ fn sign_verify_lamport_example() {
     println!("SHA256 digest: {:?}", hex::encode(message_digest));
 
     // For a 32-byte digest, we need 256 bits (32 * 8) as the message length
-    let lamport_pubkey_string = key_manager.next_lamport(256, LamportType::SHA256).unwrap();
+    let lamport_pubkey_string_example = key_manager.next_lamport(256, LamportType::SHA256).unwrap();
+
+    // Example of storing compressed public keys
+    let compressed_lamport_pubkey = lamport_pubkey_string_example.to_compressed();
+    let serialized_compressed = serde_json::to_string(&compressed_lamport_pubkey).unwrap();
+    let deserialized_compressed: LamportCompressedPubKey =
+        serde_json::from_str(&serialized_compressed).unwrap();
+    let decompressed_pubkey = key_manager
+        .expand_lamport(&deserialized_compressed)
+        .unwrap();
+    assert_eq!(
+        lamport_pubkey_string_example, decompressed_pubkey,
+        "Decompressed public key should match the original"
+    );
+
+    // Difference in size between serialized compressed and uncompressed public key
+    let serialized_uncompressed = serde_json::to_string(&lamport_pubkey_string_example).unwrap();
+    println!(
+        "\nSerialized compressed Lamport public key ({} bytes)",
+        serialized_compressed.len()
+    );
+    println!(
+        "Serialized uncompressed Lamport public key ({} bytes)",
+        serialized_uncompressed.len()
+    );
+
+    // Use the expanded key for operations
+    let lamport_pubkey_string_ex = decompressed_pubkey;
 
     // Create a Lamport signature for the message digest
     let signature_string = key_manager
-        .sign_lamport_message_by_pubkey(&message_digest, &lamport_pubkey_string)
+        .sign_lamport_message_by_pubkey(&message_digest, &lamport_pubkey_string_ex)
         .unwrap();
     println!(
         "Lamport signature for string message: {:?}",
@@ -138,7 +165,7 @@ fn sign_verify_lamport_example() {
         .verify_signature(
             Some(&message_digest),
             &signature_string,
-            &lamport_pubkey_string,
+            &lamport_pubkey_string_ex,
         )
         .unwrap();
     println!("Is string message signature valid: {:?}", is_valid_string);

--- a/examples/sign_verify_lamport.rs
+++ b/examples/sign_verify_lamport.rs
@@ -126,9 +126,9 @@ fn sign_verify_lamport_example() {
 
     // Example of storing compressed public keys
     let compressed_lamport_pubkey = lamport_pubkey_string_example.to_compressed();
-    let serialized_compressed = serde_json::to_string(&compressed_lamport_pubkey).unwrap();
+    let serialized_compressed: Vec<u8> = bincode::serialize(&compressed_lamport_pubkey).unwrap();
     let deserialized_compressed: LamportCompressedPubKey =
-        serde_json::from_str(&serialized_compressed).unwrap();
+        bincode::deserialize(&serialized_compressed).unwrap();
     let decompressed_pubkey = key_manager
         .expand_lamport(&deserialized_compressed)
         .unwrap();
@@ -138,7 +138,8 @@ fn sign_verify_lamport_example() {
     );
 
     // Difference in size between serialized compressed and uncompressed public key
-    let serialized_uncompressed = serde_json::to_string(&lamport_pubkey_string_example).unwrap();
+    let serialized_uncompressed: Vec<u8> =
+        bincode::serialize(&lamport_pubkey_string_example).unwrap();
     println!(
         "\nSerialized compressed Lamport public key ({} bytes)",
         serialized_compressed.len()

--- a/examples/sign_verify_lamport.rs
+++ b/examples/sign_verify_lamport.rs
@@ -29,6 +29,17 @@ fn sign_verify_lamport_example() {
     // Get the Lamport public key with message bit length = 1 using the SHA-256 hash function
     let lamport_pubkey = key_manager.next_lamport(1, LamportType::SHA256).unwrap();
 
+
+    // Difference in size between serialized compressed and uncompressed public key
+    println!(
+        "\nSerialized compressed Lamport public key ({} bytes)",
+        bincode::serialize(&lamport_pubkey).unwrap().len()
+    );
+    println!(
+        "Serialized uncompressed Lamport public key ({} bytes)",
+        bincode::serialize(&lamport_pubkey.to_compressed()).unwrap().len()
+    );
+
     // Create a Lamport signature
     let signature = key_manager
         .sign_lamport_message_by_pubkey(message_bit, &lamport_pubkey)

--- a/examples/sign_verify_lamport.rs
+++ b/examples/sign_verify_lamport.rs
@@ -33,11 +33,11 @@ fn sign_verify_lamport_example() {
     // Difference in size between serialized compressed and uncompressed public key
     println!(
         "\nSerialized compressed Lamport public key ({} bytes)",
-        bincode::serialize(&lamport_pubkey).unwrap().len()
+        bincode::serialize(&lamport_pubkey.to_compressed()).unwrap().len()
     );
     println!(
         "Serialized uncompressed Lamport public key ({} bytes)",
-        bincode::serialize(&lamport_pubkey.to_compressed()).unwrap().len()
+        bincode::serialize(&lamport_pubkey).unwrap().len()
     );
 
     // Create a Lamport signature

--- a/examples/sign_verify_lamport.rs
+++ b/examples/sign_verify_lamport.rs
@@ -29,11 +29,12 @@ fn sign_verify_lamport_example() {
     // Get the Lamport public key with message bit length = 1 using the SHA-256 hash function
     let lamport_pubkey = key_manager.next_lamport(1, LamportType::SHA256).unwrap();
 
-
     // Difference in size between serialized compressed and uncompressed public key
     println!(
         "\nSerialized compressed Lamport public key ({} bytes)",
-        bincode::serialize(&lamport_pubkey.to_compressed()).unwrap().len()
+        bincode::serialize(&lamport_pubkey.to_compressed())
+            .unwrap()
+            .len()
     );
     println!(
         "Serialized uncompressed Lamport public key ({} bytes)",

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -115,6 +115,9 @@ pub enum KeyManagerError {
     #[error("Lamport key derivation index not found")]
     LamportKeyDerivationIndexNotFound,
 
+    #[error("Lamport expansion fingerprint mismatch: the BLAKE3 id of the re-derived key does not match the compressed key. The seed may have changed, the keystore may have been swapped or removed, the metadata may be incorrect, or the compressed key may be corrupted.")]
+    LamportExpansionFingerprintMismatch,
+
     #[error("Invalid RSA key size: {0}")]
     InvalidRSAKeySize(String),
 

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -1577,7 +1577,7 @@ impl KeyManager {
     ) -> Result<crate::lamport::LamportPublicKey, KeyManagerError> {
         let private_key = self
             .keystore
-            .load_lamport_compressed_imported_key(compressed)?
+            .load_lamport_imported_key(compressed)?
             .ok_or(KeyManagerError::LamportPrivateKeyNotFound)?;
 
         let public_key = private_key.public_key()?;

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -1562,45 +1562,25 @@ impl KeyManager {
         &self,
         compressed: &LamportCompressedPubKey,
     ) -> Result<crate::lamport::LamportPublicKey, KeyManagerError> {
-        if compressed.imported() {
-            self.expand_lamport_imported(compressed)
+        let public_key = if compressed.imported() {
+            // For imported lamport keys: loads the stored private key by its compressed key fingerprint
+            // and derives the public key from it, then verifies the BLAKE3 fingerprint.
+            let private_key = self
+                .keystore
+                .load_lamport_imported_key(compressed)?
+                .ok_or(KeyManagerError::LamportPrivateKeyNotFound)?;
+
+            private_key.public_key()?
         } else {
-            self.expand_lamport_by_index(compressed)
-        }
-    }
+            // For derived (non-imported) lamport keys: re-derives from seed and verifies BLAKE3 fingerprint.
+            let index = compressed
+                .derivation_index()
+                .ok_or(KeyManagerError::LamportKeyDerivationIndexNotFound)?;
 
-    // For imported lamport keys: loads the stored private key by its compressed key fingerprint
-    // and derives the public key from it, then verifies the BLAKE3 fingerprint.
-    fn expand_lamport_imported(
-        &self,
-        compressed: &LamportCompressedPubKey,
-    ) -> Result<crate::lamport::LamportPublicKey, KeyManagerError> {
-        let private_key = self
-            .keystore
-            .load_lamport_imported_key(compressed)?
-            .ok_or(KeyManagerError::LamportPrivateKeyNotFound)?;
+            let message_bit_length = compressed.message_bit_length()?;
 
-        let public_key = private_key.public_key()?;
-
-        if !compressed.verify_against(&public_key) {
-            return Err(KeyManagerError::LamportExpansionFingerprintMismatch);
-        }
-
-        Ok(public_key)
-    }
-
-    // For derived (non-imported) lamport keys: re-derives from seed and verifies BLAKE3 fingerprint.
-    fn expand_lamport_by_index(
-        &self,
-        compressed: &LamportCompressedPubKey,
-    ) -> Result<crate::lamport::LamportPublicKey, KeyManagerError> {
-        let index = compressed
-            .derivation_index()
-            .ok_or(KeyManagerError::LamportKeyDerivationIndexNotFound)?;
-
-        let message_bit_length = compressed.message_bit_length()?;
-
-        let public_key = self.derive_lamport(message_bit_length, compressed.hash_type(), index)?;
+            self.derive_lamport(message_bit_length, compressed.hash_type(), index)?
+        };
 
         if !compressed.verify_against(&public_key) {
             return Err(KeyManagerError::LamportExpansionFingerprintMismatch);

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -2029,10 +2029,11 @@ mod tests {
     use zeroize::Zeroizing;
 
     use crate::{
-        errors::{KeyManagerError, WinternitzError},
+        errors::KeyManagerError,
+        errors::WinternitzError,
         key_store::KeyStore,
         key_type::BitcoinKeyType,
-        lamport::{Lamport, LamportPrivateKey, LamportType},
+        lamport::{Lamport, LamportCompressedPubKey, LamportPrivateKey, LamportType},
         rsa::RSAKeyPair,
         verifier::SignatureVerifier,
         winternitz::{to_checksummed_message, WinternitzType},
@@ -8098,5 +8099,105 @@ mod tests {
         cleanup_test_environment(&keystore_path2, &store_path2);
 
         Ok(())
+    }
+
+    // ── KeyManager::expand_lamport ────────────────────────────────────────────
+
+    #[test]
+    fn test_expand_lamport_derived_key_round_trips() -> Result<(), KeyManagerError> {
+        run_test_with_key_manager(|key_manager| {
+            let original = key_manager.next_lamport(1, LamportType::SHA256)?;
+            let compressed = original.to_compressed();
+            let expanded = key_manager.expand_lamport(&compressed)?;
+            assert_eq!(expanded, original, "expanded key must equal the original");
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_expand_lamport_imported_key_round_trips() -> Result<(), KeyManagerError> {
+        run_test_with_key_manager(|key_manager| {
+            let mut b0 = [0u8; 32];
+            let mut b1 = [0u8; 32];
+            let mut rng = secp256k1::rand::thread_rng();
+            rng.fill_bytes(&mut b0);
+            rng.fill_bytes(&mut b1);
+
+            let original =
+                key_manager.import_lamport_private_key(&b0, &b1, 1, LamportType::SHA256)?;
+            let compressed = original.to_compressed();
+            let expanded = key_manager.expand_lamport(&compressed)?;
+            assert_eq!(
+                expanded, original,
+                "expanded imported key must equal the original"
+            );
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_expand_lamport_imported_not_found_returns_error() -> Result<(), KeyManagerError> {
+        run_test_with_key_manager(|key_manager| {
+            // Build a compressed key for a private key never stored in this key manager.
+            let priv_key = LamportPrivateKey::from_bytes_splitted(
+                &[0x11u8; 32],
+                &[0x22u8; 32],
+                1,
+                LamportType::SHA256,
+                None,
+                true, // imported
+            )
+            .map_err(KeyManagerError::LamportGenerationError)?;
+            let public_key = priv_key
+                .public_key()
+                .map_err(KeyManagerError::LamportGenerationError)?;
+            let compressed = public_key.to_compressed();
+
+            let err = key_manager
+                .expand_lamport(&compressed)
+                .expect_err("must fail when imported key is not in the store");
+            assert!(
+                matches!(err, KeyManagerError::LamportPrivateKeyNotFound),
+                "unexpected error: {err}"
+            );
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_expand_lamport_missing_derivation_index_returns_error() -> Result<(), KeyManagerError> {
+        run_test_with_key_manager(|key_manager| {
+            // Import a key (so it has no derivation_index), then patch `imported=false` via JSON
+            // to simulate a derived compressed key whose derivation_index is missing.
+            let mut b0 = [0u8; 32];
+            let mut b1 = [0u8; 32];
+            let mut rng = secp256k1::rand::thread_rng();
+            rng.fill_bytes(&mut b0);
+            rng.fill_bytes(&mut b1);
+
+            let pubkey =
+                key_manager.import_lamport_private_key(&b0, &b1, 1, LamportType::SHA256)?;
+            let compressed = pubkey.to_compressed();
+
+            let mut val: serde_json::Value = serde_json::to_value(&compressed)
+                .map_err(|_| KeyManagerError::LamportKeyDerivationIndexNotFound)?;
+            val["imported"] = serde_json::Value::Bool(false);
+            if let Some(ed) = val.get_mut("extra_data") {
+                if let Some(obj) = ed.as_object_mut() {
+                    obj.insert("derivation_index".into(), serde_json::Value::Null);
+                }
+            }
+            let patched: LamportCompressedPubKey = serde_json::from_value(val)
+                .map_err(|_| KeyManagerError::LamportKeyDerivationIndexNotFound)?;
+
+            let err = key_manager
+                .expand_lamport(&patched)
+                .expect_err("must fail with missing derivation index");
+            assert!(
+                matches!(err, KeyManagerError::LamportKeyDerivationIndexNotFound),
+                "unexpected error: {err}"
+            );
+            Ok(())
+        })
     }
 }

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -22,7 +22,8 @@ use crate::{
     key_store::KeyStore,
     key_type::BitcoinKeyType,
     lamport::{
-        Lamport, LamportMessage, LamportPrivateKey, LamportPublicKey, LamportSignature, LamportType,
+        Lamport, LamportCompressedPubKey, LamportMessage, LamportPrivateKey, LamportPublicKey,
+        LamportSignature, LamportType,
     },
     musig2::{
         errors::Musig2SignerError,
@@ -1546,6 +1547,66 @@ impl KeyManager {
 
         self.commit_transaction(tx_id)?;
         Ok(signature)
+    }
+
+    /// Expands a derived (non-imported) [`LamportCompressedPubKey`] back into the full
+    /// [`LamportPublicKey`] by re-deriving it from the stored seed using the metadata
+    /// embedded in the compressed key.
+    ///
+    /// After derivation the BLAKE3 fingerprint is verified against the stored `id` to confirm
+    /// the seed has not changed or been corrupted.
+    ///
+    /// Returns an error if the derivation index or message bit length is missing, or if the
+    /// integrity check fails.
+    pub fn expand_lamport(
+        &self,
+        compressed: &LamportCompressedPubKey,
+    ) -> Result<crate::lamport::LamportPublicKey, KeyManagerError> {
+        if compressed.imported() {
+            self.expand_lamport_imported(compressed)
+        } else {
+            self.expand_lamport_by_index(compressed)
+        }
+    }
+
+    // For imported lamport keys: loads the stored private key by its compressed key fingerprint
+    // and derives the public key from it, then verifies the BLAKE3 fingerprint.
+    fn expand_lamport_imported(
+        &self,
+        compressed: &LamportCompressedPubKey,
+    ) -> Result<crate::lamport::LamportPublicKey, KeyManagerError> {
+        let private_key = self
+            .keystore
+            .load_lamport_compressed_imported_key(compressed)?
+            .ok_or(KeyManagerError::LamportPrivateKeyNotFound)?;
+
+        let public_key = private_key.public_key()?;
+
+        if !compressed.verify_against(&public_key) {
+            return Err(KeyManagerError::LamportExpansionFingerprintMismatch);
+        }
+
+        Ok(public_key)
+    }
+
+    // For derived (non-imported) lamport keys: re-derives from seed and verifies BLAKE3 fingerprint.
+    fn expand_lamport_by_index(
+        &self,
+        compressed: &LamportCompressedPubKey,
+    ) -> Result<crate::lamport::LamportPublicKey, KeyManagerError> {
+        let index = compressed
+            .derivation_index()
+            .ok_or(KeyManagerError::LamportKeyDerivationIndexNotFound)?;
+
+        let message_bit_length = compressed.message_bit_length()?;
+
+        let public_key = self.derive_lamport(message_bit_length, compressed.hash_type(), index)?;
+
+        if !compressed.verify_against(&public_key) {
+            return Err(KeyManagerError::LamportExpansionFingerprintMismatch);
+        }
+
+        Ok(public_key)
     }
 
     /// Exports the private key for a given public key.

--- a/src/key_store.rs
+++ b/src/key_store.rs
@@ -1,7 +1,7 @@
 use crate::{
     errors::KeyManagerError,
     key_type::BitcoinKeyType,
-    lamport::{LamportCompressedPubKey, LamportPrivateKey, LamportPublicKey},
+    lamport::{LamportPrivateKey, LamportPubKeyId, LamportPublicKey},
     rsa::RSAKeyPair,
 };
 use base64::{engine::general_purpose, Engine as _};
@@ -349,17 +349,10 @@ impl KeyStore {
         Ok(None)
     }
 
-    // TODO template?
-    fn format_lamport_storage_key(public_key: &LamportPublicKey) -> String {
-        // compressed pubkey (blake3) justification: This lamport key could be large to use it as storage key, impacting into rocksdb performance
-        let hash = public_key.to_compressed().id();
-        format!("{}:{}", Self::LAMPORT, hash.to_hex())
-    }
-
-    fn format_lamport_compressed_storage_key(comp_public_key: &LamportCompressedPubKey) -> String {
-        // compressed pubkey (blake3) justification: This lamport key could be large to use it as storage key, impacting into rocksdb performance
-        let hash = comp_public_key.id();
-        format!("{}:{}", Self::LAMPORT, hash.to_hex())
+    // Blake3 fingerprint justification: the full LamportPublicKey can be large; using its
+    // BLAKE3 hash as the storage key avoids rocksdb performance issues with big keys.
+    fn format_lamport_storage_key<K: LamportPubKeyId>(key: &K) -> String {
+        format!("{}:{}", Self::LAMPORT, key.key_id().to_hex())
     }
 
     fn format_lamport_storage_value(private_key: &LamportPrivateKey) -> String {
@@ -383,11 +376,10 @@ impl KeyStore {
         Ok(())
     }
 
-    // TODO template?
     // we are not storing derived keys
-    pub fn load_lamport_imported_key(
+    pub fn load_lamport_imported_key<K: LamportPubKeyId>(
         &self,
-        public_key: &LamportPublicKey,
+        public_key: &K,
     ) -> Result<Option<LamportPrivateKey>, KeyManagerError> {
         let pubk = Self::format_lamport_storage_key(public_key);
         let privk: Option<Zeroizing<String>> =
@@ -413,51 +405,6 @@ impl KeyStore {
                 &private_key_decoded,
                 public_key.message_bit_length()?,
                 public_key.hash_type(),
-                None,
-                true, // imported: true for imported keys
-            )?;
-
-            // Set the spent flag
-            if spent {
-                private_key.mark_spent();
-            }
-
-            return Ok(Some(private_key));
-        }
-
-        Ok(None)
-    }
-
-    // TODO template?
-    // we are not storing derived keys
-    pub fn load_lamport_compressed_imported_key(
-        &self,
-        comp_public_key: &LamportCompressedPubKey,
-    ) -> Result<Option<LamportPrivateKey>, KeyManagerError> {
-        let pubk = Self::format_lamport_compressed_storage_key(comp_public_key);
-        let privk: Option<Zeroizing<String>> =
-            self.store.get::<String, String>(pubk)?.map(Zeroizing::new);
-
-        if let Some(privk) = privk {
-            let parts: Vec<&str> = privk.split(':').collect();
-
-            // Expected format: lamport:base64_key:spent
-            if parts.len() != 3 || parts[0] != Self::LAMPORT {
-                return Err(KeyManagerError::InvalidLamportPrivateKey);
-            }
-
-            let key_bytes_part = parts[1];
-            let spent = parts[2]
-                .parse::<bool>()
-                .map_err(|_| KeyManagerError::InvalidLamportPrivateKey)?;
-
-            let private_key_decoded = general_purpose::STANDARD
-                .decode(key_bytes_part.as_bytes())
-                .map_err(|_| KeyManagerError::InvalidLamportPrivateKey)?;
-            let mut private_key = LamportPrivateKey::from_bytes(
-                &private_key_decoded,
-                comp_public_key.message_bit_length()?,
-                comp_public_key.hash_type(),
                 None,
                 true, // imported: true for imported keys
             )?;

--- a/src/key_store.rs
+++ b/src/key_store.rs
@@ -1,7 +1,7 @@
 use crate::{
     errors::KeyManagerError,
     key_type::BitcoinKeyType,
-    lamport::{LamportPrivateKey, LamportPublicKey},
+    lamport::{LamportCompressedPubKey, LamportPrivateKey, LamportPublicKey},
     rsa::RSAKeyPair,
 };
 use base64::{engine::general_purpose, Engine as _};
@@ -349,10 +349,16 @@ impl KeyStore {
         Ok(None)
     }
 
+    // TODO template?
     fn format_lamport_storage_key(public_key: &LamportPublicKey) -> String {
         // compressed pubkey (blake3) justification: This lamport key could be large to use it as storage key, impacting into rocksdb performance
-        let pubkey_bytes = public_key.to_bytes();
-        let hash = blake3::hash(&pubkey_bytes);
+        let hash = public_key.to_compressed().id();
+        format!("{}:{}", Self::LAMPORT, hash.to_hex())
+    }
+
+    fn format_lamport_compressed_storage_key(comp_public_key: &LamportCompressedPubKey) -> String {
+        // compressed pubkey (blake3) justification: This lamport key could be large to use it as storage key, impacting into rocksdb performance
+        let hash = comp_public_key.id();
         format!("{}:{}", Self::LAMPORT, hash.to_hex())
     }
 
@@ -377,6 +383,7 @@ impl KeyStore {
         Ok(())
     }
 
+    // TODO template?
     // we are not storing derived keys
     pub fn load_lamport_imported_key(
         &self,
@@ -406,6 +413,51 @@ impl KeyStore {
                 &private_key_decoded,
                 public_key.message_bit_length()?,
                 public_key.hash_type(),
+                None,
+                true, // imported: true for imported keys
+            )?;
+
+            // Set the spent flag
+            if spent {
+                private_key.mark_spent();
+            }
+
+            return Ok(Some(private_key));
+        }
+
+        Ok(None)
+    }
+
+    // TODO template?
+    // we are not storing derived keys
+    pub fn load_lamport_compressed_imported_key(
+        &self,
+        comp_public_key: &LamportCompressedPubKey,
+    ) -> Result<Option<LamportPrivateKey>, KeyManagerError> {
+        let pubk = Self::format_lamport_compressed_storage_key(comp_public_key);
+        let privk: Option<Zeroizing<String>> =
+            self.store.get::<String, String>(pubk)?.map(Zeroizing::new);
+
+        if let Some(privk) = privk {
+            let parts: Vec<&str> = privk.split(':').collect();
+
+            // Expected format: lamport:base64_key:spent
+            if parts.len() != 3 || parts[0] != Self::LAMPORT {
+                return Err(KeyManagerError::InvalidLamportPrivateKey);
+            }
+
+            let key_bytes_part = parts[1];
+            let spent = parts[2]
+                .parse::<bool>()
+                .map_err(|_| KeyManagerError::InvalidLamportPrivateKey)?;
+
+            let private_key_decoded = general_purpose::STANDARD
+                .decode(key_bytes_part.as_bytes())
+                .map_err(|_| KeyManagerError::InvalidLamportPrivateKey)?;
+            let mut private_key = LamportPrivateKey::from_bytes(
+                &private_key_decoded,
+                comp_public_key.message_bit_length()?,
+                comp_public_key.hash_type(),
                 None,
                 true, // imported: true for imported keys
             )?;

--- a/src/key_store.rs
+++ b/src/key_store.rs
@@ -350,7 +350,7 @@ impl KeyStore {
     }
 
     fn format_lamport_storage_key(public_key: &LamportPublicKey) -> String {
-        // blake3 justification: This lamport key could be large to use it as storage key, impacting into rocksdb performance
+        // compressed pubkey (blake3) justification: This lamport key could be large to use it as storage key, impacting into rocksdb performance
         let pubkey_bytes = public_key.to_bytes();
         let hash = blake3::hash(&pubkey_bytes);
         format!("{}:{}", Self::LAMPORT, hash.to_hex())

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -556,6 +556,81 @@ impl LamportPublicKey {
     }
 }
 
+/// A compressed representation of a Lamport public key.
+///
+/// Stores only the key metadata plus an `id` that is the BLAKE3 hash
+/// of the full serialized public key bytes (`LamportPublicKey::to_bytes()`).
+///
+/// This lets callers:
+/// - Store a tiny fingerprint instead of the full (potentially large) public key.
+/// - Regenerate the full public key from the seed + metadata, then verify integrity
+///   by re-computing BLAKE3 and comparing against the stored `id`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LamportCompressedPubKey {
+    /// BLAKE3 hash of the serialized public key bytes, used as a compact,
+    /// collision-resistant identifier.  Re-derive the key and recompute to verify
+    /// the seed/key has not changed.  Call `.to_hex()` on it to get a hex string.
+    id: blake3::Hash,
+    hash_type: LamportType,
+    imported: bool, // if the key was imported or derived. imported = true, derive = false
+    extra_data: Option<ExtraData>,
+}
+
+impl LamportCompressedPubKey {
+    /// Build a `LamportCompressedPubKey` from a live `LamportPublicKey`, computing
+    /// the BLAKE3 fingerprint automatically.
+    pub fn from_public_key(pubk: &LamportPublicKey) -> Self {
+        LamportCompressedPubKey {
+            id: blake3::hash(&pubk.to_bytes()),
+            hash_type: pubk.hash_type(),
+            imported: pubk.imported(),
+            extra_data: pubk.extra_data(),
+        }
+    }
+
+    /// BLAKE3 hash of the serialized public key bytes.
+    /// Call `.to_hex()` on the returned value to get a hex string:
+    /// `compressed.id().to_hex().to_string()`
+    pub fn id(&self) -> blake3::Hash {
+        self.id
+    }
+
+    pub fn hash_type(&self) -> LamportType {
+        self.hash_type
+    }
+
+    pub fn imported(&self) -> bool {
+        self.imported
+    }
+
+    pub fn extra_data(&self) -> Option<&ExtraData> {
+        self.extra_data.as_ref()
+    }
+
+    pub fn message_bit_length(&self) -> Result<usize, LamportError> {
+        self.extra_data
+            .as_ref()
+            .ok_or(LamportError::ExtraDataMissing("message_bit_length".to_string()))
+            .map(|d| d.message_bit_length())
+    }
+
+    pub fn derivation_index(&self) -> Option<u32> {
+        self.extra_data.as_ref().and_then(|d| d.derivation_index())
+    }
+
+    /// Verify that a regenerated `LamportPublicKey` matches this compressed key.
+    /// Returns `true` if its BLAKE3 hash equals the stored `id`.
+    pub fn verify_against(&self, pk: &LamportPublicKey) -> bool {
+        blake3::hash(&pk.to_bytes()) == self.id
+    }
+}
+
+impl From<&LamportPublicKey> for LamportCompressedPubKey {
+    fn from(pk: &LamportPublicKey) -> Self {
+        Self::from_public_key(pk)
+    }
+}
+
 /// Lamport private key containing two sets of secret values:
 /// - private_key_0s: secrets for when the corresponding bit is 0
 /// - private_key_1s: secrets for when the corresponding bit is 1

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -1041,6 +1041,41 @@ impl<const N: usize> LamportMessage for &[u8; N] {
     }
 }
 
+/// Trait for types that can provide a BLAKE3 fingerprint identifying a Lamport public key.
+///
+/// Implemented by both [`LamportPublicKey`] (computes the hash on the fly) and
+/// [`LamportCompressedPubKey`] (returns its stored `id`), allowing a single generic
+/// function to accept either form — see [`KeyStore::format_lamport_key`](crate::key_store).
+pub trait LamportPubKeyId {
+    fn key_id(&self) -> blake3::Hash;
+    fn message_bit_length(&self) -> Result<usize, LamportError>;
+    fn hash_type(&self) -> LamportType;
+}
+
+impl LamportPubKeyId for LamportPublicKey {
+    fn key_id(&self) -> blake3::Hash {
+        self.to_compressed().id()
+    }
+    fn message_bit_length(&self) -> Result<usize, LamportError> {
+        LamportPublicKey::message_bit_length(self)
+    }
+    fn hash_type(&self) -> LamportType {
+        LamportPublicKey::hash_type(self)
+    }
+}
+
+impl LamportPubKeyId for LamportCompressedPubKey {
+    fn key_id(&self) -> blake3::Hash {
+        self.id()
+    }
+    fn message_bit_length(&self) -> Result<usize, LamportError> {
+        LamportCompressedPubKey::message_bit_length(self)
+    }
+    fn hash_type(&self) -> LamportType {
+        LamportCompressedPubKey::hash_type(self)
+    }
+}
+
 // ========== Main Lamport Implementation ==========
 
 /// Main Lamport signature scheme implementation

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -610,7 +610,9 @@ impl LamportCompressedPubKey {
     pub fn message_bit_length(&self) -> Result<usize, LamportError> {
         self.extra_data
             .as_ref()
-            .ok_or(LamportError::ExtraDataMissing("message_bit_length".to_string()))
+            .ok_or(LamportError::ExtraDataMissing(
+                "message_bit_length".to_string(),
+            ))
             .map(|d| d.message_bit_length())
     }
 

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -537,6 +537,10 @@ impl LamportPublicKey {
         self.imported
     }
 
+    pub fn to_compressed(&self) -> LamportCompressedPubKey {
+        LamportCompressedPubKey::from_public_key(self)
+    }
+
     fn public_key_0_at(&self, index: usize) -> Result<&LamportHash, LamportError> {
         self.public_key_0s
             .get(index)

--- a/src/lamport.rs
+++ b/src/lamport.rs
@@ -3148,4 +3148,153 @@ mod tests {
         assert_eq!(private_key.derivation_index(), Some(derivation_index));
         assert_eq!(public_key.derivation_index(), Some(derivation_index));
     }
+
+    // ── LamportCompressedPubKey ───────────────────────────────────────────────
+
+    fn derived_pubkey_for_compression() -> LamportPublicKey {
+        Lamport::new()
+            .generate_private_key(
+                b"test_compression_secret_12345678",
+                LamportType::SHA256,
+                1,
+                0,
+            )
+            .unwrap()
+            .public_key()
+            .unwrap()
+    }
+
+    fn imported_pubkey_for_compression() -> LamportPublicKey {
+        let hash_type = LamportType::SHA256;
+        let message_bit_length = 1;
+        let key_bytes = vec![0x42u8; 2 * message_bit_length * hash_type.hash_size()];
+        LamportPrivateKey::from_bytes(&key_bytes, message_bit_length, hash_type, None, true)
+            .unwrap()
+            .public_key()
+            .unwrap()
+    }
+
+    #[test]
+    fn test_compressed_from_public_key_preserves_hash_type_and_imported_flag() {
+        let pubkey = derived_pubkey_for_compression();
+        let compressed = LamportCompressedPubKey::from_public_key(&pubkey);
+        assert_eq!(compressed.hash_type(), LamportType::SHA256);
+        assert!(!compressed.imported());
+    }
+
+    #[test]
+    fn test_compressed_to_compressed_matches_from_public_key() {
+        let pubkey = derived_pubkey_for_compression();
+        assert_eq!(
+            pubkey.to_compressed(),
+            LamportCompressedPubKey::from_public_key(&pubkey)
+        );
+    }
+
+    #[test]
+    fn test_compressed_from_trait_matches_from_public_key() {
+        let pubkey = derived_pubkey_for_compression();
+        assert_eq!(
+            LamportCompressedPubKey::from(&pubkey),
+            LamportCompressedPubKey::from_public_key(&pubkey)
+        );
+    }
+
+    #[test]
+    fn test_compressed_id_is_blake3_hash_of_serialized_key() {
+        let pubkey = derived_pubkey_for_compression();
+        let compressed = pubkey.to_compressed();
+        assert_eq!(compressed.id(), blake3::hash(&pubkey.to_bytes()));
+    }
+
+    #[test]
+    fn test_compressed_different_keys_produce_different_ids() {
+        let lamport = Lamport::new();
+        let master = b"test_compression_secret_12345678";
+        let pk_a = lamport
+            .generate_private_key(master, LamportType::SHA256, 1, 0)
+            .unwrap()
+            .public_key()
+            .unwrap();
+        let pk_b = lamport
+            .generate_private_key(master, LamportType::SHA256, 1, 1)
+            .unwrap()
+            .public_key()
+            .unwrap();
+        assert_ne!(pk_a.to_compressed().id(), pk_b.to_compressed().id());
+    }
+
+    #[test]
+    fn test_compressed_message_bit_length_round_trips() {
+        let pubkey = derived_pubkey_for_compression();
+        assert_eq!(pubkey.to_compressed().message_bit_length().unwrap(), 1);
+    }
+
+    #[test]
+    fn test_compressed_derivation_index_present_for_derived_key() {
+        let pubkey = derived_pubkey_for_compression();
+        assert!(pubkey.to_compressed().derivation_index().is_some());
+    }
+
+    #[test]
+    fn test_compressed_verify_against_same_key() {
+        let pubkey = derived_pubkey_for_compression();
+        let compressed = pubkey.to_compressed();
+        assert!(compressed.verify_against(&pubkey));
+    }
+
+    #[test]
+    fn test_compressed_verify_against_different_key_fails() {
+        let lamport = Lamport::new();
+        let master = b"test_compression_secret_12345678";
+        let pk_a = lamport
+            .generate_private_key(master, LamportType::SHA256, 1, 0)
+            .unwrap()
+            .public_key()
+            .unwrap();
+        let pk_b = lamport
+            .generate_private_key(master, LamportType::SHA256, 1, 1)
+            .unwrap()
+            .public_key()
+            .unwrap();
+        assert!(!pk_a.to_compressed().verify_against(&pk_b));
+    }
+
+    #[test]
+    fn test_compressed_imported_key_flag() {
+        let pubkey = imported_pubkey_for_compression();
+        assert!(pubkey.to_compressed().imported());
+    }
+
+    // ── LamportPubKeyId trait ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_pub_key_id_trait_full_and_compressed_agree() {
+        let pubkey = derived_pubkey_for_compression();
+        let compressed = pubkey.to_compressed();
+        assert_eq!(
+            LamportPubKeyId::key_id(&pubkey),
+            LamportPubKeyId::key_id(&compressed)
+        );
+    }
+
+    #[test]
+    fn test_pub_key_id_trait_message_bit_length_agrees() {
+        let pubkey = derived_pubkey_for_compression();
+        let compressed = pubkey.to_compressed();
+        assert_eq!(
+            LamportPubKeyId::message_bit_length(&pubkey).unwrap(),
+            LamportPubKeyId::message_bit_length(&compressed).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_pub_key_id_trait_hash_type_agrees() {
+        let pubkey = derived_pubkey_for_compression();
+        let compressed = pubkey.to_compressed();
+        assert_eq!(
+            LamportPubKeyId::hash_type(&pubkey),
+            LamportPubKeyId::hash_type(&compressed)
+        );
+    }
 }


### PR DESCRIPTION
## Add compressed lamport pubkey fingerprint

This PR introduces a compressed representation of `LamportPublicKey` to reduce storage and transmission size, along with a matching expansion API that re-derives or reloads the full key and verifies integrity via BLAKE3.



## Motivation

A Lamport public key grows linearly with the message bit length: a key for a 256-bit message already serialises to several kilobytes. Storing or passing the full key around adds unnecessary overhead. This PR addresses that by separating the *identity* of a key (its BLAKE3 fingerprint + metadata) from its *full material*.

Example size comparison (from the updated example output):

| Form | Bytes (1-bit key) | Bytes (256-bit key) |
|---|---|---|
| Compressed | 51 | 51 |
| Uncompressed | 115 | 20,515 |

The ratio grows with `message_bit_length`.

---

## Changes

### New type - `LamportCompressedPubKey` 

- `LamportPublicKey::to_compressed()` and the `From<&LamportPublicKey>` impl construct it automatically.
- `verify_against(&LamportPublicKey)` checks that a re-derived key still matches the stored fingerprint.

### New trait - `LamportPubKeyId` 
Implemented by both `LamportPublicKey` (computes on the fly) and `LamportCompressedPubKey` (returns stored `id`). Used to unify operations.

### New function - `KeyManager::expand_lamport()`

Reconstructs the full `LamportPublicKey`

- **Derived keys** — re-derives from the seed using the embedded derivation index and message bit length.
- **Imported keys** — loads the stored private key from the keystore and derives the public key from it.

After reconstruction, the BLAKE3 fingerprint is verified against the stored `id`

## Tests

Unit tests have been added 