### PR TITLE
Fix the error handling test case 3 for windows

### DIFF
--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -2104,9 +2104,11 @@ mod tests {
         // Case 2: Invalid derivation path (not possible)
 
         // Case 3 b: Write error when creating database keystore (invalid path)
-        //TODO: FIX THIS TEST is not working in windows envs
-        //let result = database_keystore("/invalid/path");
-        //assert!(matches!(result, Err(KeyStoreError::WriteError(_))));
+        #[cfg(windows)]
+        let result = database_keystore("C:\\invalid<>path\\::");
+        #[cfg(not(windows))]
+        let result = database_keystore("/invalid/path");
+        assert!(matches!(result, Err(KeyManagerError::StorageError(_))));
 
         // Case 4: Index overflow when generating keys
         let result =


### PR DESCRIPTION
Added a patch for the 3rd scenario of the error handling test cases, this fixes an error in windows execution.